### PR TITLE
Eliminate usage of MS isNullOrEmpty Extension Method for SecurityKeys

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -12,7 +12,7 @@ concurrency:
   # this will disable CI parellelism
   # TODO: refactor use of test users to allow running in parallel
 
-
+# Jobs
 jobs:
   test:
     permissions:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -12,7 +12,6 @@ concurrency:
   # this will disable CI parellelism
   # TODO: refactor use of test users to allow running in parallel
 
-# Jobs
 jobs:
   test:
     permissions:

--- a/Descope/Internal/Authentication/Authentication.cs
+++ b/Descope/Internal/Authentication/Authentication.cs
@@ -153,7 +153,7 @@ namespace Descope.Internal.Auth
 
         private async Task FetchKeyIfNeeded()
         {
-            if (!_securityKeys.IsNullOrEmpty()) return;
+            if (_securityKeys != null && _securityKeys.Count > 0) return;
 
             var response = await _httpClient.Get<JwtKeyResponse>(Routes.AuthKeys + $"{_httpClient.DescopeConfig.ProjectId}");
             foreach (var key in response.Keys)


### PR DESCRIPTION
## Related Issues

Fixes <https://github.com/descope/etc/issues/10247>

## Description

Eliminated usage of isNullOrEmpty() for SecurityKeys object since this extension method has been made internal in Microsoft.IdentityModel.Tokens version 8 and up. 

## Must

- [ ] Tests
- [ ] Documentation (if applicable)
