### PR TITLE
feat: add tenant roles user search parameters

### DIFF
--- a/Descope/Types/Types.cs
+++ b/Descope/Types/Types.cs
@@ -437,6 +437,10 @@ namespace Descope
         public bool WithTestUsers { get; set; }
         [JsonPropertyName("testUsersOnly")]
         public bool TestUsersOnly { get; set; }
+        [JsonPropertyName("tenantRoleIds")]
+        public Dictionary<string, List<string>>? TenantRoleIds { get; set; }
+        [JsonPropertyName("tenantRoleNames")]
+        public Dictionary<string, List<string>>? TenantRoleNames { get; set; }
     }
 
     public class UserSearchSort


### PR DESCRIPTION
## Related Issues

Fixes https://github.com/descope/etc/issues/11275

## Description

Added TenantRoleIds and TenantRoleNames user search parameters to allow for searching by tenants and roles.
