### PR TITLE
Fix empty string behavior patch

### DIFF
--- a/Descope/Internal/Management/User.cs
+++ b/Descope/Internal/Management/User.cs
@@ -370,7 +370,6 @@ namespace Descope.Internal.Management
             {
                 {"loginId", loginId}
             };
-            // For Patch: include field if it's not null (even if empty string), skip if null
             if (request.Email != null) body["email"] = request.Email;
             if (request.Phone != null) body["phone"] = request.Phone;
             if (request.Name != null) body["displayName"] = request.Name;


### PR DESCRIPTION
## Related Issues

Fixes <link_to_github_issue>

## Related PRs

| branch       | PR         |
| ------------ | ---------- |
| service a PR | Link to PR |
| service b PR | Link to PR |

## Description

When passing empty string patch would not pass it along to API so nothing would get erased. 

## Must

- [ ] Tests
- [ ] Documentation (if applicable)
