### PR TITLE
DO NOT MERGE - OLD BRANCH FIX: allow multiple concurrent calls to validate session before a public key is cached

### DIFF
--- a/Descope/Internal/Authentication/Authentication.cs
+++ b/Descope/Internal/Authentication/Authentication.cs
@@ -193,11 +193,8 @@ namespace Descope.Internal.Auth
                 _securityKeys.AddOrUpdate(
                     key.Kid,
                     _ => new List<SecurityKey> { new RsaSecurityKey(rsa) },
-                    (_, existingKeys) =>
-                    {
-                        existingKeys.Add(new RsaSecurityKey(rsa));
-                        return existingKeys;
-                    });
+                    (_, existingKeys) => new List<SecurityKey>(existingKeys) { new RsaSecurityKey(rsa) }
+                );
             }
         }
 


### PR DESCRIPTION
## Related Issues

Fixes:
- https://github.com/descope/etc/issues/13256

## Related PRs
- Fix for `1.x.x`: https://github.com/descope/descope-dotnet/pull/124

## Description

This pull request addresses a (rare) race condition in JWT validation by making the internal key cache thread-safe.

## Must

- [ ] Tests
- [ ] Documentation (if applicable)
