### PR TITLE
chore(ci): work on v0

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+      - main-v0
   pull_request:
 
 concurrency:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -3,10 +3,13 @@ name: Upload dotnet package
 on:
   release:
     types: [created]
+  push:
+    tags:
+      - "0.*.*"
 
 env:
   PACKAGE_NAME: Descope
-  RELEASE_VERSION: ${{ github.event.release.tag_name }}
+  RELEASE_VERSION: ${{ github.event.release.tag_name || github.ref_name }}
 
 jobs:
   publish:


### PR DESCRIPTION
This pull request updates the GitHub Actions workflows to improve CI and release processes. The main changes ensure that CI runs on an additional branch and that the release workflow can be triggered by both releases and version tags, with improved handling of the release version variable.

**CI workflow improvements:**

- [`.github/workflows/ci.yaml`](diffhunk://#diff-944291df2c9c06359d37cc8833d182d705c9e8c3108e7cfe132d61a06e9133ddR7): Updated the workflow to also run on pushes to the `main-v0` branch, in addition to `main`.

**Release workflow enhancements:**

- [`.github/workflows/release.yaml`](diffhunk://#diff-e426ed45842837026e10e66af23d9c7077e89eacbe6958ce7cb991130ad05adaR6-R12): Modified the workflow to trigger on pushes to tags matching the pattern `0.*.*`, in addition to releases.
- [`.github/workflows/release.yaml`](diffhunk://#diff-e426ed45842837026e10e66af23d9c7077e89eacbe6958ce7cb991130ad05adaR6-R12): Improved the `RELEASE_VERSION` environment variable to use either the release tag name or the Git reference name, ensuring correct versioning for both triggers.