### PR TITLE
fix: release please version xpath

### DIFF
--- a/.release-please-config.json
+++ b/.release-please-config.json
@@ -4,7 +4,6 @@
     "packages": {
         ".": {
             "package-name": "Descope",
-            "version-file": "Descope/Descope.csproj",
             "extra-files": [
                 {
                     "type": "xml",


### PR DESCRIPTION
This pull request makes a small configuration change to the release process for the Descope package.

- Removed the `version-file` entry from the Descope package configuration in `.release-please-config.json`, to adjust how versioning is managed for releases.

Instead of overwriting the whole file, just change the xpath property