### PR TITLE
fix: do not append descope headers twice when using DI to create the SDK client

### DIFF
--- a/Descope.Test/UnitTests/Internal/DescopeHttpHeadersTests.cs
+++ b/Descope.Test/UnitTests/Internal/DescopeHttpHeadersTests.cs
@@ -1,0 +1,115 @@
+using System.Net.Http;
+using Descope;
+using Xunit;
+
+namespace Descope.Test.UnitTests.Internal;
+
+public class DescopeHttpHeadersTests
+{
+    [Fact]
+    public void ConfigureHeaders_ShouldAddRequiredHeaders()
+    {
+        // Arrange
+        var httpClient = new HttpClient();
+        var projectId = "test_project_id";
+
+        // Act
+        DescopeHttpHeaders.ConfigureHeaders(httpClient, projectId);
+
+        // Assert
+        Assert.True(httpClient.DefaultRequestHeaders.Contains("x-descope-sdk-name"));
+        Assert.True(httpClient.DefaultRequestHeaders.Contains("x-descope-sdk-version"));
+        Assert.True(httpClient.DefaultRequestHeaders.Contains("x-descope-sdk-dotnet-version"));
+        Assert.True(httpClient.DefaultRequestHeaders.Contains("x-descope-project-id"));
+        Assert.Equal(projectId, httpClient.DefaultRequestHeaders.GetValues("x-descope-project-id").Single());
+    }
+
+    [Fact]
+    public void ConfigureHeaders_CalledTwice_ShouldNotDuplicateHeaders()
+    {
+        // Arrange
+        var httpClient = new HttpClient();
+        var projectId = "test_project_id";
+
+        // Act - call ConfigureHeaders twice (this was the bug)
+        DescopeHttpHeaders.ConfigureHeaders(httpClient, projectId);
+        DescopeHttpHeaders.ConfigureHeaders(httpClient, projectId);
+
+        // Assert - each header should only have one value, not duplicated
+        var projectIdValues = httpClient.DefaultRequestHeaders.GetValues("x-descope-project-id").ToList();
+        Assert.Single(projectIdValues);
+        Assert.Equal(projectId, projectIdValues[0]);
+
+        var sdkNameValues = httpClient.DefaultRequestHeaders.GetValues("x-descope-sdk-name").ToList();
+        Assert.Single(sdkNameValues);
+
+        var sdkVersionValues = httpClient.DefaultRequestHeaders.GetValues("x-descope-sdk-version").ToList();
+        Assert.Single(sdkVersionValues);
+
+        var dotnetVersionValues = httpClient.DefaultRequestHeaders.GetValues("x-descope-sdk-dotnet-version").ToList();
+        Assert.Single(dotnetVersionValues);
+    }
+
+    [Fact]
+    public void ConfigureHeaders_CalledMultipleTimes_ShouldRemainIdempotent()
+    {
+        // Arrange
+        var httpClient = new HttpClient();
+        var projectId = "test_project_id";
+
+        // Act - call ConfigureHeaders many times
+        for (int i = 0; i < 10; i++)
+        {
+            DescopeHttpHeaders.ConfigureHeaders(httpClient, projectId);
+        }
+
+        // Assert - headers should still only have single values
+        var projectIdValues = httpClient.DefaultRequestHeaders.GetValues("x-descope-project-id").ToList();
+        Assert.Single(projectIdValues);
+        Assert.Equal(projectId, projectIdValues[0]);
+    }
+
+    [Fact]
+    public void ConfigureHeaders_WithNullHttpClient_ShouldThrowArgumentNullException()
+    {
+        // Arrange
+        HttpClient httpClient = null!;
+        var projectId = "test_project_id";
+
+        // Act & Assert
+        Assert.Throws<ArgumentNullException>(() => DescopeHttpHeaders.ConfigureHeaders(httpClient, projectId));
+    }
+
+    [Fact]
+    public void ConfigureHeaders_WithNullProjectId_ShouldThrowArgumentException()
+    {
+        // Arrange
+        var httpClient = new HttpClient();
+        string projectId = null!;
+
+        // Act & Assert
+        Assert.Throws<ArgumentException>(() => DescopeHttpHeaders.ConfigureHeaders(httpClient, projectId));
+    }
+
+    [Fact]
+    public void ConfigureHeaders_WithEmptyProjectId_ShouldThrowArgumentException()
+    {
+        // Arrange
+        var httpClient = new HttpClient();
+        var projectId = "";
+
+        // Act & Assert
+        Assert.Throws<ArgumentException>(() => DescopeHttpHeaders.ConfigureHeaders(httpClient, projectId));
+    }
+
+    [Fact]
+    public void ConfigureHeaders_WithWhitespaceProjectId_ShouldThrowArgumentException()
+    {
+        // Arrange
+        var httpClient = new HttpClient();
+        var projectId = "   ";
+
+        // Act & Assert
+        Assert.Throws<ArgumentException>(() => DescopeHttpHeaders.ConfigureHeaders(httpClient, projectId));
+    }
+}

--- a/Descope/Sdk/Factories/DescopeServiceCollectionExtensions.cs
+++ b/Descope/Sdk/Factories/DescopeServiceCollectionExtensions.cs
@@ -72,9 +72,11 @@ public static class DescopeServiceCollectionExtensions
             var httpClientFactory = sp.GetRequiredService<IHttpClientFactory>();
             var httpClient = httpClientFactory.CreateClient(httpClientName);
 
+            // Configure Descope headers once for the shared HttpClient
+            DescopeHttpHeaders.ConfigureHeaders(httpClient, options.ProjectId);
+
             // Create management Kiota client
             var mgmtAuthProvider = new DescopeAuthenticationProvider(options.ProjectId, options.ManagementKey);
-            DescopeHttpHeaders.ConfigureHeaders(httpClient, options.ProjectId);
             var mgmtAdapter = new HttpClientRequestAdapter(mgmtAuthProvider, httpClient: httpClient)
             {
                 BaseUrl = options.BaseUrl
@@ -83,7 +85,6 @@ public static class DescopeServiceCollectionExtensions
 
             // Create auth Kiota client
             var authAuthProvider = new DescopeAuthenticationProvider(options.ProjectId, null, options.AuthManagementKey);
-            DescopeHttpHeaders.ConfigureHeaders(httpClient, options.ProjectId);
             var authAdapter = new HttpClientRequestAdapter(authAuthProvider, httpClient: httpClient)
             {
                 BaseUrl = options.BaseUrl

--- a/Descope/Sdk/Internal/DescopeHttpHeaders.cs
+++ b/Descope/Sdk/Internal/DescopeHttpHeaders.cs
@@ -11,6 +11,8 @@ internal static class DescopeHttpHeaders
 {
     /// <summary>
     /// Configures an HttpClient with required Descope headers.
+    /// This method is idempotent - calling it multiple times on the same HttpClient
+    /// will not duplicate headers.
     /// </summary>
     /// <param name="httpClient">The HttpClient to configure.</param>
     /// <param name="projectId">The Descope Project ID.</param>
@@ -26,10 +28,21 @@ internal static class DescopeHttpHeaders
             throw new ArgumentException("Project ID is required", nameof(projectId));
         }
 
-        // Add Descope SDK headers
-        httpClient.DefaultRequestHeaders.Add("x-descope-sdk-name", SdkInfo.Name);
-        httpClient.DefaultRequestHeaders.Add("x-descope-sdk-version", SdkInfo.Version);
-        httpClient.DefaultRequestHeaders.Add("x-descope-sdk-dotnet-version", SdkInfo.DotNetVersion);
-        httpClient.DefaultRequestHeaders.Add("x-descope-project-id", projectId);
+        // Add Descope SDK headers only if they don't already exist (idempotent)
+        TryAddHeader(httpClient, "x-descope-sdk-name", SdkInfo.Name);
+        TryAddHeader(httpClient, "x-descope-sdk-version", SdkInfo.Version);
+        TryAddHeader(httpClient, "x-descope-sdk-dotnet-version", SdkInfo.DotNetVersion);
+        TryAddHeader(httpClient, "x-descope-project-id", projectId);
+    }
+
+    /// <summary>
+    /// Adds a header to the HttpClient only if it doesn't already exist.
+    /// </summary>
+    private static void TryAddHeader(HttpClient httpClient, string name, string value)
+    {
+        if (!httpClient.DefaultRequestHeaders.Contains(name))
+        {
+            httpClient.DefaultRequestHeaders.Add(name, value);
+        }
     }
 }


### PR DESCRIPTION
## Related Issues

Potentially Fixes:
- https://github.com/descope/etc/issues/14033

## Description

This PR fixes a bug where Descope SDK headers were being added multiple times to HttpClient instances when using dependency injection, causing header duplication.
It is not immediately clear if this actually had adverse effects on SDK users, but it should be fixed either way.

## Must

- [x] Tests
- [ ] Documentation (if applicable)
