### PR TITLE
feat: add DPoP sender-constrained token support (RFC 9449)

### DIFF
--- a/Descope/Sdk/Auth/DPoPValidator.cs
+++ b/Descope/Sdk/Auth/DPoPValidator.cs
@@ -1,0 +1,568 @@
+using System;
+using System.Collections.Generic;
+using System.Security.Cryptography;
+using System.Text;
+using System.Text.Json;
+using Newtonsoft.Json;
+
+namespace Descope;
+
+/// <summary>
+/// Validates DPoP (Demonstrated Proof of Possession) proofs per RFC 9449.
+/// </summary>
+internal static class DPoPValidator
+{
+    private const int MaxProofLength = 8192;
+    private const int IatBackwardWindowSeconds = 60;
+    private const int IatForwardWindowSeconds = 5;
+
+    private static readonly HashSet<string> AllowedAlgorithms = new HashSet<string>(StringComparer.Ordinal)
+    {
+        "RS256", "RS384", "RS512",
+        "ES256", "ES384", "ES512",
+        "PS256", "PS384", "PS512",
+        "EdDSA"
+    };
+
+    /// <summary>
+    /// Validates a DPoP proof JWT against the provided access token.
+    /// If the session token has no cnf.jkt claim, validation is skipped (token is not DPoP-bound).
+    /// </summary>
+    /// <param name="dpopProof">The DPoP proof JWT from the DPoP header.</param>
+    /// <param name="method">The HTTP method (e.g. "GET", "POST").</param>
+    /// <param name="requestUrl">The request URL.</param>
+    /// <param name="sessionToken">The session/access token JWT string.</param>
+    /// <exception cref="DescopeException">Thrown if the DPoP proof is invalid.</exception>
+    public static void ValidateDPoPProof(string dpopProof, string method, string requestUrl, string sessionToken)
+    {
+        // Extract the JWK thumbprint from the session token.
+        // If there is no cnf.jkt claim, the token is not DPoP-bound — skip validation.
+        var storedJkt = GetJktFromToken(sessionToken);
+        if (string.IsNullOrEmpty(storedJkt))
+        {
+            return;
+        }
+
+        dpopProof = dpopProof?.Trim() ?? string.Empty;
+
+        if (dpopProof.Length > MaxProofLength)
+            throw new DescopeException("DPoP proof exceeds maximum length");
+
+        if (dpopProof.Length == 0)
+            throw new DescopeException("DPoP proof required");
+
+        var parts = dpopProof.Split('.');
+        if (parts.Length != 3)
+            throw new DescopeException("malformed DPoP JWT");
+
+        // --- Parse header ---
+        Dictionary<string, object>? header;
+        try
+        {
+            var headerBytes = Base64UrlDecode(parts[0]);
+            header = System.Text.Json.JsonSerializer.Deserialize<Dictionary<string, object>>(headerBytes);
+        }
+        catch (Exception ex)
+        {
+            throw new DescopeException("failed to parse DPoP header", ex);
+        }
+
+        if (header == null)
+            throw new DescopeException("failed to parse DPoP header");
+
+        if (!TryGetString(header, "typ", out var typ) || typ != "dpop+jwt")
+            throw new DescopeException("typ must be dpop+jwt");
+
+        if (!TryGetString(header, "alg", out var alg) || string.IsNullOrEmpty(alg))
+            throw new DescopeException("missing alg in DPoP header");
+
+        if (!AllowedAlgorithms.Contains(alg))
+            throw new DescopeException($"rejected algorithm: {alg}");
+
+        if (!TryGetObject(header, "jwk", out var jwk) || jwk == null)
+            throw new DescopeException("missing jwk header");
+
+        if (TryGetString(jwk, "kty", out var kty) && kty == "oct")
+            throw new DescopeException("symmetric key not allowed");
+
+        if (jwk.ContainsKey("d"))
+            throw new DescopeException("jwk must not contain a private key");
+
+        // --- Verify JWS signature ---
+        var signingInput = Encoding.UTF8.GetBytes(parts[0] + "." + parts[1]);
+        byte[] signatureBytes;
+        try
+        {
+            signatureBytes = Base64UrlDecode(parts[2]);
+        }
+        catch (Exception ex)
+        {
+            throw new DescopeException("failed to decode DPoP signature", ex);
+        }
+
+        VerifySignature(alg, jwk, signingInput, signatureBytes);
+
+        // --- Parse payload ---
+        Dictionary<string, object>? payload;
+        try
+        {
+            var payloadBytes = Base64UrlDecode(parts[1]);
+            payload = System.Text.Json.JsonSerializer.Deserialize<Dictionary<string, object>>(payloadBytes);
+        }
+        catch (Exception ex)
+        {
+            throw new DescopeException("failed to parse DPoP payload", ex);
+        }
+
+        if (payload == null)
+            throw new DescopeException("failed to parse DPoP payload");
+
+        if (!TryGetString(payload, "jti", out var jti) || string.IsNullOrEmpty(jti))
+            throw new DescopeException("missing or empty jti claim");
+
+        if (!TryGetString(payload, "htm", out var htm) || string.IsNullOrEmpty(htm))
+            throw new DescopeException("missing or empty htm claim");
+
+        if (!TryGetString(payload, "htu", out var htu) || string.IsNullOrEmpty(htu))
+            throw new DescopeException("missing or empty htu claim");
+
+        if (!string.Equals(htm, method, StringComparison.OrdinalIgnoreCase))
+            throw new DescopeException($"htm mismatch: expected {method}, got {htm}");
+
+        if (!HtuMatches(htu, requestUrl))
+            throw new DescopeException($"htu mismatch: expected {requestUrl}, got {htu}");
+
+        // --- Validate iat ---
+        long iat;
+        if (!TryGetLong(payload, "iat", out iat))
+            throw new DescopeException("missing or invalid iat claim");
+
+        var now = DateTimeOffset.UtcNow.ToUnixTimeSeconds();
+        var diff = now - iat;
+
+        if (diff <= -IatForwardWindowSeconds || diff >= IatBackwardWindowSeconds)
+            throw new DescopeException("iat out of acceptable window");
+
+        // --- Validate ath (access token hash) ---
+        if (!TryGetString(payload, "ath", out var ath) || string.IsNullOrEmpty(ath))
+            throw new DescopeException("missing ath claim");
+
+        var tokenBytes = Encoding.UTF8.GetBytes(sessionToken);
+#if NET6_0_OR_GREATER
+        var tokenHash = SHA256.HashData(tokenBytes);
+#else
+        byte[] tokenHash;
+        using (var sha = SHA256.Create())
+        {
+            tokenHash = sha.ComputeHash(tokenBytes);
+        }
+#endif
+        var expectedAth = Base64UrlEncode(tokenHash);
+        if (ath != expectedAth)
+            throw new DescopeException("ath mismatch");
+
+        // --- Validate JWK thumbprint against cnf.jkt ---
+        if (!TryGetString(jwk, "kty", out var jwkKty) || string.IsNullOrEmpty(jwkKty))
+            throw new DescopeException("missing kty in jwk");
+
+        var thumbprint = ComputeJwkThumbprint(jwkKty, jwk);
+        if (thumbprint != storedJkt)
+            throw new DescopeException("DPoP key mismatch: jwk thumbprint does not match cnf.jkt");
+    }
+
+    /// <summary>
+    /// Extracts the cnf.jkt claim from a raw session JWT string without full validation.
+    /// Returns empty string if not present or on any parse error.
+    /// </summary>
+    public static string GetJktFromToken(string sessionToken)
+    {
+        if (string.IsNullOrEmpty(sessionToken))
+            return string.Empty;
+
+        try
+        {
+            var parts = sessionToken.Split('.');
+            if (parts.Length < 2)
+                return string.Empty;
+
+            var payloadBytes = Base64UrlDecode(parts[1]);
+            var payload = System.Text.Json.JsonSerializer.Deserialize<Dictionary<string, object>>(payloadBytes);
+            if (payload == null)
+                return string.Empty;
+
+            if (!TryGetObject(payload, "cnf", out var cnf) || cnf == null)
+                return string.Empty;
+
+            if (!TryGetString(cnf, "jkt", out var jkt))
+                return string.Empty;
+
+            return jkt ?? string.Empty;
+        }
+        catch
+        {
+            return string.Empty;
+        }
+    }
+
+    // -----------------------------------------------------------------------
+    // Private helpers
+    // -----------------------------------------------------------------------
+
+    private static void VerifySignature(
+        string alg,
+        Dictionary<string, object> jwk,
+        byte[] signingInput,
+        byte[] signature)
+    {
+        try
+        {
+            if (alg.StartsWith("RS", StringComparison.Ordinal) || alg.StartsWith("PS", StringComparison.Ordinal))
+            {
+                VerifyRsaSignature(alg, jwk, signingInput, signature);
+            }
+            else if (alg.StartsWith("ES", StringComparison.Ordinal))
+            {
+                VerifyEcSignature(alg, jwk, signingInput, signature);
+            }
+            else if (alg == "EdDSA")
+            {
+                // EdDSA (Ed25519) is listed as an allowed algorithm in RFC 9449, but .NET does not
+                // expose a stable public API for Ed25519 signature verification across all target
+                // frameworks. Support may be added in a future release.
+                throw new DescopeException("EdDSA DPoP proofs are not yet supported by this SDK");
+            }
+            else
+            {
+                throw new DescopeException($"unsupported algorithm: {alg}");
+            }
+        }
+        catch (DescopeException)
+        {
+            throw;
+        }
+        catch (Exception ex)
+        {
+            throw new DescopeException("DPoP signature verification failed", ex);
+        }
+    }
+
+    private static void VerifyRsaSignature(
+        string alg,
+        Dictionary<string, object> jwk,
+        byte[] signingInput,
+        byte[] signature)
+    {
+        if (!TryGetString(jwk, "n", out var n) || !TryGetString(jwk, "e", out var e)
+            || string.IsNullOrEmpty(n) || string.IsNullOrEmpty(e))
+            throw new DescopeException("RSA jwk missing n or e");
+
+        using var rsa = RSA.Create();
+        rsa.ImportParameters(new RSAParameters
+        {
+            Modulus = Base64UrlDecode(n!),
+            Exponent = Base64UrlDecode(e!),
+        });
+
+        var (hashAlg, padding) = alg switch
+        {
+            "RS256" => (HashAlgorithmName.SHA256, RSASignaturePadding.Pkcs1),
+            "RS384" => (HashAlgorithmName.SHA384, RSASignaturePadding.Pkcs1),
+            "RS512" => (HashAlgorithmName.SHA512, RSASignaturePadding.Pkcs1),
+            "PS256" => (HashAlgorithmName.SHA256, RSASignaturePadding.Pss),
+            "PS384" => (HashAlgorithmName.SHA384, RSASignaturePadding.Pss),
+            "PS512" => (HashAlgorithmName.SHA512, RSASignaturePadding.Pss),
+            _ => throw new DescopeException($"unsupported RSA algorithm: {alg}")
+        };
+
+        if (!rsa.VerifyData(signingInput, signature, hashAlg, padding))
+            throw new DescopeException("DPoP signature verification failed");
+    }
+
+    private static void VerifyEcSignature(
+        string alg,
+        Dictionary<string, object> jwk,
+        byte[] signingInput,
+        byte[] signature)
+    {
+        if (!TryGetString(jwk, "x", out var x) || !TryGetString(jwk, "y", out var y)
+            || string.IsNullOrEmpty(x) || string.IsNullOrEmpty(y))
+            throw new DescopeException("EC jwk missing x or y");
+
+        if (!TryGetString(jwk, "crv", out var crv) || string.IsNullOrEmpty(crv))
+            throw new DescopeException("EC jwk missing crv");
+
+        var (curve, hashAlg) = crv switch
+        {
+            "P-256" => (ECCurve.NamedCurves.nistP256, HashAlgorithmName.SHA256),
+            "P-384" => (ECCurve.NamedCurves.nistP384, HashAlgorithmName.SHA384),
+            "P-521" => (ECCurve.NamedCurves.nistP521, HashAlgorithmName.SHA512),
+            _ => throw new DescopeException($"unsupported EC curve: {crv}")
+        };
+
+        using var ec = ECDsa.Create();
+        ec.ImportParameters(new ECParameters
+        {
+            Curve = curve,
+            Q = new ECPoint
+            {
+                X = Base64UrlDecode(x!),
+                Y = Base64UrlDecode(y!),
+            }
+        });
+
+        // DPoP/JWT EC signatures are in raw IEEE P1363 (R||S) format.
+#if NET6_0_OR_GREATER
+        if (!ec.VerifyData(signingInput, signature, hashAlg, DSASignatureFormat.IeeeP1363FixedFieldConcatenation))
+            throw new DescopeException("DPoP signature verification failed");
+#else
+        // Convert raw R||S to DER for netstandard2.0 / older targets.
+        var derSig = ConvertRawToDer(signature);
+        if (!ec.VerifyData(signingInput, derSig, hashAlg))
+            throw new DescopeException("DPoP signature verification failed");
+#endif
+    }
+
+    /// <summary>
+    /// Converts a raw R||S EC signature to DER format (for netstandard2.0 compatibility).
+    /// </summary>
+    private static byte[] ConvertRawToDer(byte[] rawSig)
+    {
+        int halfLen = rawSig.Length / 2;
+        var r = new byte[halfLen];
+        var s = new byte[halfLen];
+        Array.Copy(rawSig, 0, r, 0, halfLen);
+        Array.Copy(rawSig, halfLen, s, 0, halfLen);
+
+        // Strip leading zeros, then add 0x00 prefix if high bit set.
+        r = TrimAndPadInteger(r);
+        s = TrimAndPadInteger(s);
+
+        int seqContentLen = 2 + r.Length + 2 + s.Length;
+        var der = new byte[2 + seqContentLen];
+        int pos = 0;
+        der[pos++] = 0x30; // SEQUENCE
+        der[pos++] = (byte)seqContentLen;
+        der[pos++] = 0x02; // INTEGER
+        der[pos++] = (byte)r.Length;
+        Array.Copy(r, 0, der, pos, r.Length);
+        pos += r.Length;
+        der[pos++] = 0x02; // INTEGER
+        der[pos++] = (byte)s.Length;
+        Array.Copy(s, 0, der, pos, s.Length);
+        return der;
+    }
+
+    private static byte[] TrimAndPadInteger(byte[] val)
+    {
+        // Remove leading zeros.
+        int start = 0;
+        while (start < val.Length - 1 && val[start] == 0)
+            start++;
+        var trimmed = new byte[val.Length - start];
+        Array.Copy(val, start, trimmed, 0, trimmed.Length);
+
+        // If high bit set, prepend 0x00 to indicate positive integer.
+        if (trimmed[0] >= 0x80)
+        {
+            var padded = new byte[trimmed.Length + 1];
+            padded[0] = 0x00;
+            Array.Copy(trimmed, 0, padded, 1, trimmed.Length);
+            return padded;
+        }
+        return trimmed;
+    }
+
+    /// <summary>
+    /// Checks that the htu claim matches the request URL (scheme+host+path, no query/fragment).
+    /// </summary>
+    private static bool HtuMatches(string htu, string requestUrl)
+    {
+        try
+        {
+            var htuUri = new Uri(htu);
+            var reqUri = new Uri(requestUrl);
+
+            // Normalize: lowercase scheme and host, strip default ports, strip query/fragment.
+            var htuNorm = NormalizeUri(htuUri);
+            var reqNorm = NormalizeUri(reqUri);
+            return string.Equals(htuNorm, reqNorm, StringComparison.Ordinal);
+        }
+        catch
+        {
+            return false;
+        }
+    }
+
+    private static string NormalizeUri(Uri uri)
+    {
+        var scheme = uri.Scheme.ToLowerInvariant();
+        var host = uri.Host.ToLowerInvariant();
+        var path = uri.AbsolutePath;
+
+        // Determine whether the port is the default for the scheme.
+        bool isDefault = (scheme == "https" && uri.Port == 443)
+                      || (scheme == "http" && uri.Port == 80)
+                      || uri.IsDefaultPort;
+
+        var authority = isDefault ? host : $"{host}:{uri.Port}";
+        return $"{scheme}://{authority}{path}";
+    }
+
+    /// <summary>
+    /// Computes the RFC 7638 JWK thumbprint.
+    /// </summary>
+    private static string ComputeJwkThumbprint(string kty, Dictionary<string, object> jwk)
+    {
+        // Required members per key type, in lexicographic order.
+        var members = new SortedDictionary<string, string>(StringComparer.Ordinal);
+
+        switch (kty)
+        {
+            case "EC":
+                if (!TryGetString(jwk, "crv", out var ecCrv) || string.IsNullOrEmpty(ecCrv))
+                    throw new DescopeException("EC jwk missing crv for thumbprint");
+                if (!TryGetString(jwk, "x", out var ecX) || string.IsNullOrEmpty(ecX))
+                    throw new DescopeException("EC jwk missing x for thumbprint");
+                if (!TryGetString(jwk, "y", out var ecY) || string.IsNullOrEmpty(ecY))
+                    throw new DescopeException("EC jwk missing y for thumbprint");
+                members["crv"] = ecCrv!;
+                members["kty"] = "EC";
+                members["x"] = ecX!;
+                members["y"] = ecY!;
+                break;
+
+            case "RSA":
+                if (!TryGetString(jwk, "e", out var rsaE) || string.IsNullOrEmpty(rsaE))
+                    throw new DescopeException("RSA jwk missing e for thumbprint");
+                if (!TryGetString(jwk, "n", out var rsaN) || string.IsNullOrEmpty(rsaN))
+                    throw new DescopeException("RSA jwk missing n for thumbprint");
+                members["e"] = rsaE!;
+                members["kty"] = "RSA";
+                members["n"] = rsaN!;
+                break;
+
+            case "OKP":
+                if (!TryGetString(jwk, "crv", out var okpCrv) || string.IsNullOrEmpty(okpCrv))
+                    throw new DescopeException("OKP jwk missing crv for thumbprint");
+                if (!TryGetString(jwk, "x", out var okpX) || string.IsNullOrEmpty(okpX))
+                    throw new DescopeException("OKP jwk missing x for thumbprint");
+                members["crv"] = okpCrv!;
+                members["kty"] = "OKP";
+                members["x"] = okpX!;
+                break;
+
+            default:
+                throw new DescopeException($"unsupported kty for thumbprint: {kty}");
+        }
+
+        var json = JsonConvert.SerializeObject(members, Formatting.None);
+        var jsonBytes = Encoding.UTF8.GetBytes(json);
+
+#if NET6_0_OR_GREATER
+        var digest = SHA256.HashData(jsonBytes);
+#else
+        byte[] digest;
+        using (var sha = SHA256.Create())
+        {
+            digest = sha.ComputeHash(jsonBytes);
+        }
+#endif
+        return Base64UrlEncode(digest);
+    }
+
+    // -----------------------------------------------------------------------
+    // Base64Url helpers
+    // -----------------------------------------------------------------------
+
+    internal static byte[] Base64UrlDecode(string s)
+    {
+        s = s.Replace('-', '+').Replace('_', '/');
+        switch (s.Length % 4)
+        {
+            case 2: s += "=="; break;
+            case 3: s += "="; break;
+        }
+        return Convert.FromBase64String(s);
+    }
+
+    internal static string Base64UrlEncode(byte[] bytes)
+    {
+        return Convert.ToBase64String(bytes).TrimEnd('=').Replace('+', '-').Replace('/', '_');
+    }
+
+    // -----------------------------------------------------------------------
+    // Claim value extraction helpers
+    // (handles both raw string and System.Text.Json.JsonElement values)
+    // -----------------------------------------------------------------------
+
+    private static bool TryGetString(Dictionary<string, object> dict, string key, out string? value)
+    {
+        value = null;
+        if (!dict.TryGetValue(key, out var raw) || raw == null)
+            return false;
+
+        if (raw is string s)
+        {
+            value = s;
+            return true;
+        }
+
+        if (raw is JsonElement el && el.ValueKind == JsonValueKind.String)
+        {
+            value = el.GetString();
+            return true;
+        }
+
+        return false;
+    }
+
+    private static bool TryGetLong(Dictionary<string, object> dict, string key, out long value)
+    {
+        value = 0;
+        if (!dict.TryGetValue(key, out var raw) || raw == null)
+            return false;
+
+        if (raw is long l) { value = l; return true; }
+        if (raw is int i) { value = i; return true; }
+        if (raw is double d) { value = (long)d; return true; }
+
+        if (raw is JsonElement el)
+        {
+            if (el.ValueKind == JsonValueKind.Number && el.TryGetInt64(out var v))
+            {
+                value = v;
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private static bool TryGetObject(Dictionary<string, object> dict, string key, out Dictionary<string, object>? value)
+    {
+        value = null;
+        if (!dict.TryGetValue(key, out var raw) || raw == null)
+            return false;
+
+        if (raw is Dictionary<string, object> d)
+        {
+            value = d;
+            return true;
+        }
+
+        if (raw is JsonElement el && el.ValueKind == JsonValueKind.Object)
+        {
+            try
+            {
+                value = System.Text.Json.JsonSerializer.Deserialize<Dictionary<string, object>>(el.GetRawText());
+                return value != null;
+            }
+            catch
+            {
+                return false;
+            }
+        }
+
+        return false;
+    }
+}

--- a/Descope/Sdk/Auth/DPoPValidator.cs
+++ b/Descope/Sdk/Auth/DPoPValidator.cs
@@ -21,7 +21,6 @@ internal static class DPoPValidator
         "RS256", "RS384", "RS512",
         "ES256", "ES384", "ES512",
         "PS256", "PS384", "PS512",
-        "EdDSA"
     };
 
     /// <summary>
@@ -172,23 +171,25 @@ internal static class DPoPValidator
 
     /// <summary>
     /// Extracts the cnf.jkt claim from a raw session JWT string without full validation.
-    /// Returns empty string if not present or on any parse error.
+    /// Throws if the session token is null/empty or cannot be parsed (fail-closed).
+    /// Returns empty string only when the token is valid but has no cnf.jkt claim,
+    /// which means the token is not DPoP-bound and validation should be skipped.
     /// </summary>
     public static string GetJktFromToken(string sessionToken)
     {
         if (string.IsNullOrEmpty(sessionToken))
-            return string.Empty;
+            throw new DescopeException("session token is required for DPoP validation");
+
+        var parts = sessionToken.Split('.');
+        if (parts.Length < 2)
+            throw new DescopeException("malformed session token");
 
         try
         {
-            var parts = sessionToken.Split('.');
-            if (parts.Length < 2)
-                return string.Empty;
-
             var payloadBytes = Base64UrlDecode(parts[1]);
             var payload = System.Text.Json.JsonSerializer.Deserialize<Dictionary<string, object>>(payloadBytes);
             if (payload == null)
-                return string.Empty;
+                throw new DescopeException("failed to parse session token payload");
 
             if (!TryGetObject(payload, "cnf", out var cnf) || cnf == null)
                 return string.Empty;
@@ -198,9 +199,13 @@ internal static class DPoPValidator
 
             return jkt ?? string.Empty;
         }
-        catch
+        catch (DescopeException)
         {
-            return string.Empty;
+            throw;
+        }
+        catch (Exception ex)
+        {
+            throw new DescopeException("failed to parse session token", ex);
         }
     }
 
@@ -223,13 +228,6 @@ internal static class DPoPValidator
             else if (alg.StartsWith("ES", StringComparison.Ordinal))
             {
                 VerifyEcSignature(alg, jwk, signingInput, signature);
-            }
-            else if (alg == "EdDSA")
-            {
-                // EdDSA (Ed25519) is listed as an allowed algorithm in RFC 9449, but .NET does not
-                // expose a stable public API for Ed25519 signature verification across all target
-                // frameworks. Support may be added in a future release.
-                throw new DescopeException("EdDSA DPoP proofs are not yet supported by this SDK");
             }
             else
             {
@@ -291,13 +289,17 @@ internal static class DPoPValidator
         if (!TryGetString(jwk, "crv", out var crv) || string.IsNullOrEmpty(crv))
             throw new DescopeException("EC jwk missing crv");
 
-        var (curve, hashAlg) = crv switch
+        // Drive curve and hash from alg; validate crv matches to catch mismatch attacks.
+        var (expectedCrv, curve, hashAlg) = alg switch
         {
-            "P-256" => (ECCurve.NamedCurves.nistP256, HashAlgorithmName.SHA256),
-            "P-384" => (ECCurve.NamedCurves.nistP384, HashAlgorithmName.SHA384),
-            "P-521" => (ECCurve.NamedCurves.nistP521, HashAlgorithmName.SHA512),
-            _ => throw new DescopeException($"unsupported EC curve: {crv}")
+            "ES256" => ("P-256", ECCurve.NamedCurves.nistP256, HashAlgorithmName.SHA256),
+            "ES384" => ("P-384", ECCurve.NamedCurves.nistP384, HashAlgorithmName.SHA384),
+            "ES512" => ("P-521", ECCurve.NamedCurves.nistP521, HashAlgorithmName.SHA512),
+            _ => throw new DescopeException($"unsupported EC algorithm: {alg}")
         };
+
+        if (!string.Equals(crv, expectedCrv, StringComparison.Ordinal))
+            throw new DescopeException($"EC alg/curve mismatch: alg {alg} requires {expectedCrv} but jwk has crv={crv}");
 
         using var ec = ECDsa.Create();
         ec.ImportParameters(new ECParameters
@@ -323,7 +325,23 @@ internal static class DPoPValidator
     }
 
     /// <summary>
+    /// Encodes a DER length field using short-form (1 byte) or long-form (multi-byte) as required.
+    /// Per X.690, lengths > 127 must use long-form: 0x80|numBytes followed by the length bytes.
+    /// For ES512 (P-521), the SEQUENCE content is ~134 bytes so long-form is required.
+    /// </summary>
+    private static byte[] EncodeDerLength(int len)
+    {
+        if (len < 128)
+            return new[] { (byte)len };
+        if (len < 256)
+            return new byte[] { 0x81, (byte)len };
+        return new byte[] { 0x82, (byte)(len >> 8), (byte)(len & 0xFF) };
+    }
+
+    /// <summary>
     /// Converts a raw R||S EC signature to DER format (for netstandard2.0 compatibility).
+    /// Handles ES512 (P-521) where the SEQUENCE content exceeds 127 bytes and requires
+    /// DER long-form length encoding.
     /// </summary>
     private static byte[] ConvertRawToDer(byte[] rawSig)
     {
@@ -338,16 +356,21 @@ internal static class DPoPValidator
         s = TrimAndPadInteger(s);
 
         int seqContentLen = 2 + r.Length + 2 + s.Length;
-        var der = new byte[2 + seqContentLen];
+        var seqLen = EncodeDerLength(seqContentLen);
+        var rLen = EncodeDerLength(r.Length);
+        var sLen = EncodeDerLength(s.Length);
+
+        // Total: 1 (0x30) + seqLen + 1 (0x02) + rLen + r + 1 (0x02) + sLen + s
+        int totalLen = 1 + seqLen.Length + 1 + rLen.Length + r.Length + 1 + sLen.Length + s.Length;
+        var der = new byte[totalLen];
         int pos = 0;
         der[pos++] = 0x30; // SEQUENCE
-        der[pos++] = (byte)seqContentLen;
-        der[pos++] = 0x02; // INTEGER
-        der[pos++] = (byte)r.Length;
-        Array.Copy(r, 0, der, pos, r.Length);
-        pos += r.Length;
-        der[pos++] = 0x02; // INTEGER
-        der[pos++] = (byte)s.Length;
+        Array.Copy(seqLen, 0, der, pos, seqLen.Length); pos += seqLen.Length;
+        der[pos++] = 0x02; // INTEGER r
+        Array.Copy(rLen, 0, der, pos, rLen.Length); pos += rLen.Length;
+        Array.Copy(r, 0, der, pos, r.Length); pos += r.Length;
+        der[pos++] = 0x02; // INTEGER s
+        Array.Copy(sLen, 0, der, pos, sLen.Length); pos += sLen.Length;
         Array.Copy(s, 0, der, pos, s.Length);
         return der;
     }

--- a/Descope/Sdk/Auth/ITokenActions.cs
+++ b/Descope/Sdk/Auth/ITokenActions.cs
@@ -46,4 +46,16 @@ public interface ITokenActions
     /// <exception cref="Exception">Thrown when the exchange fails or token parsing fails.</exception>
     Task<Token> ExchangeAccessKey(string accessKey, Auth.Models.Onetimev1.AccessKeyLoginOptions? loginOptions = null);
 
+    /// <summary>
+    /// Validates a DPoP (Demonstrated Proof of Possession) proof JWT against a session token (RFC 9449).
+    /// If the session token does not have a <c>cnf.jkt</c> claim it is not DPoP-bound and this method
+    /// returns immediately without error.
+    /// </summary>
+    /// <param name="sessionToken">The validated session JWT string.</param>
+    /// <param name="dpopProof">The DPoP proof JWT from the <c>DPoP</c> HTTP header.</param>
+    /// <param name="method">The HTTP method of the request (e.g. "GET", "POST").</param>
+    /// <param name="requestUrl">The full request URL.</param>
+    /// <exception cref="DescopeException">Thrown when the DPoP proof is missing or invalid.</exception>
+    void ValidateDPoP(string sessionToken, string dpopProof, string method, string requestUrl);
+
 }

--- a/Descope/Sdk/Auth/TokenActions.cs
+++ b/Descope/Sdk/Auth/TokenActions.cs
@@ -110,4 +110,10 @@ internal class TokenActions : ITokenActions
         return await _jwtValidator.ValidateToken(response.SessionJwt);
 
     }
+
+    /// <inheritdoc/>
+    public void ValidateDPoP(string sessionToken, string dpopProof, string method, string requestUrl)
+    {
+        DPoPValidator.ValidateDPoPProof(dpopProof, method, requestUrl, sessionToken);
+    }
 }

--- a/Descope/Sdk/DescopeClient.cs
+++ b/Descope/Sdk/DescopeClient.cs
@@ -79,6 +79,10 @@ public class DescopeClient : IDescopeClient
         public async Task<Token> ExchangeAccessKey(string accessKey, Auth.Models.Onetimev1.AccessKeyLoginOptions? loginOptions = null) =>
             await _tokenActions.ExchangeAccessKey(accessKey, loginOptions);
 
+        /// <inheritdoc/>
+        public void ValidateDPoP(string sessionToken, string dpopProof, string method, string requestUrl) =>
+            _tokenActions.ValidateDPoP(sessionToken, dpopProof, method, requestUrl);
+
     }
 
     /// <inheritdoc/>

--- a/README.md
+++ b/README.md
@@ -155,6 +155,29 @@ var token = await client.Auth.ValidateAndRefreshSession(sessionJwt, refreshJwt);
 
 **Performance Note:** Validation calls (`ValidateSessionAsync`, `ValidateAndRefreshSession`) are highly efficient as they use locally cached public keys. Only `RefreshSessionAsync` and the refresh fallback in `ValidateAndRefreshSession` make remote API calls.
 
+### DPoP Sender-Constrained Tokens
+
+When a session token contains a `cnf.jkt` claim it is DPoP-bound (RFC 9449). The client must prove possession of the corresponding private key on every resource-server request by including a signed `DPoP` proof JWT in the `DPoP` HTTP header. Use `ValidateDPoP` on the resource server to verify the proof before granting access:
+
+```csharp
+// On the resource server, after validating the session JWT:
+var token = await client.Auth.ValidateSessionAsync(sessionJwt);
+
+// Retrieve the DPoP proof from the incoming request header (e.g. in ASP.NET Core):
+var dpopProof = httpContext.Request.Headers["DPoP"].ToString();
+
+// Validate the proof — throws DescopeException if invalid.
+// No-ops if the token is not DPoP-bound (no cnf.jkt claim).
+client.Auth.ValidateDPoP(sessionJwt, dpopProof, httpContext.Request.Method, $"{httpContext.Request.Scheme}://{httpContext.Request.Host}{httpContext.Request.Path}");
+```
+
+`ValidateDPoP` verifies:
+- The DPoP JWT header (`typ`, `alg`, `jwk`) and signature
+- The `htm` (HTTP method) and `htu` (URL) claims match the request
+- The `iat` is within a ±60/5 second window
+- The `ath` claim matches SHA-256 of the access token
+- The JWK thumbprint matches the `cnf.jkt` claim in the session token
+
 ## Authenticated User Operations
 
 Some authentication operations require an authenticated user context and must be called with a refresh JWT. For these operations, use the `PostWithJwt` extension methods that explicitly require the refresh token.


### PR DESCRIPTION
## Summary

- Implements DPoP proof validation (RFC 9449 §7.1-7.2): header/signature/payload checks, `iat` window, `ath` (access token hash), and JWK thumbprint vs `cnf.jkt`
- Adds `ValidateDPoP(sessionToken, dpopProof, method, requestUrl)` to `ITokenActions` and `TokenActions`; no-ops when the token has no `cnf.jkt` claim
- Mirrors the Go SDK implementation: https://github.com/descope/go-sdk/pull/737

## Test plan

- [ ] Unit test: valid EC/RSA DPoP proof passes
- [ ] Unit test: tampered signature throws `DescopeException`
- [ ] Unit test: `iat` outside window throws
- [ ] Unit test: `ath` mismatch throws
- [ ] Unit test: JWK thumbprint mismatch throws
- [ ] Unit test: token without `cnf.jkt` skips validation (no-op)

🤖 Generated with [Claude Code](https://claude.com/claude-code)