### PR TITLE
feat(http): also retry on transient status code 520

### DIFF
--- a/Descope.Test/UnitTests/Internal/DescopeErrorResponseHandlerTests.cs
+++ b/Descope.Test/UnitTests/Internal/DescopeErrorResponseHandlerTests.cs
@@ -29,6 +29,7 @@ public class DescopeErrorResponseHandlerTests
 
     [Theory]
     [InlineData(503)]
+    [InlineData(520)]
     [InlineData(521)]
     [InlineData(522)]
     [InlineData(524)]

--- a/Descope/Sdk/Errors/DescopeErrorResponseHandler.cs
+++ b/Descope/Sdk/Errors/DescopeErrorResponseHandler.cs
@@ -19,11 +19,12 @@ internal class DescopeErrorResponseHandler : DelegatingHandler
 {
     // HTTP status codes that should trigger automatic retries:
     // 503: Service Unavailable
+    // 520: Web Server Returned an Unknown Error (Cloudflare)
     // 521: Web Server Is Down (Cloudflare)
     // 522: Connection Timed Out (Cloudflare)
     // 524: A Timeout Occurred (Cloudflare)
     // 530: Cloudflare error
-    private static readonly HashSet<int> RetryableStatusCodes = new HashSet<int> { 503, 521, 522, 524, 530 };
+    private static readonly HashSet<int> RetryableStatusCodes = new HashSet<int> { 503, 520, 521, 522, 524, 530 };
 
     // Default retry delays: first retry after 100ms, subsequent retries after 5s each.
     // Exposed as internal so tests can assert on the production values.


### PR DESCRIPTION
## Summary

Add Cloudflare status code `520` ("Web Server Returned an Unknown Error") to the HTTP client's retryable status codes, alongside the existing `503` / `521` / `522` / `524` / `530`.

Like the other Cloudflare 52x codes already retried, `520` is a transient edge error returned when the origin is briefly unreachable (e.g. during pod replacement on deploy), so the request is safe to retry. Follow-up to #190; brings this SDK in line with go-sdk (descope/go-sdk#775), python-sdk (descope/python-sdk#1581) and core-js-sdk (descope/descope-js#1423).

https://github.com/descope/etc/issues/14039

## Test plan

- [x] Added `520` to the retryable-status-codes test/data set, mirroring the existing per-code coverage
- [ ] CI runs the full suite

🤖 Generated with [Claude Code](https://claude.com/claude-code)