### PR TITLE
fix(mgmt): add convenience wrappers for tenant, user, and third-party lo

### DIFF
--- a/Descope.Test/UnitTests/Management/MgmtExtensionsTests.cs
+++ b/Descope.Test/UnitTests/Management/MgmtExtensionsTests.cs
@@ -569,6 +569,128 @@ public class MgmtExtensionsTests
     }
 
     /// <summary>
+    /// Tests that GetWithTenantIdAsync for Tenant Settings correctly passes the tenant ID.
+    /// </summary>
+    [Fact]
+    public async Task TenantSettings_GetWithTenantIdAsync_PassesTenantIdCorrectly()
+    {
+        // Arrange
+        var testTenantId = "test-tenant-id";
+
+        var descopeClient = TestDescopeClientFactory.CreateWithAsserter<GetTenantSettingsResponse>(
+            requestInfo =>
+            {
+                requestInfo.QueryParameters.Should().ContainKey("id", "The tenant ID should be in query parameters");
+                requestInfo.QueryParameters["id"].Should().Be(testTenantId, "The tenant ID should match");
+                return new GetTenantSettingsResponse();
+            });
+
+        // Act
+        await descopeClient.Mgmt.V1.Tenant.Settings.GetWithTenantIdAsync(testTenantId);
+    }
+
+    /// <summary>
+    /// Tests that GetWithTenantIdAsync for Tenant Settings throws when tenant ID is null or empty.
+    /// </summary>
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    public async Task TenantSettings_GetWithTenantIdAsync_ThrowsDescopeException_WhenTenantIdIsMissing(string? tenantId)
+    {
+        // Arrange
+        var descopeClient = TestDescopeClientFactory.CreateWithEmptyResponse();
+
+        // Act & Assert
+        await Assert.ThrowsAsync<DescopeException>(async () =>
+        {
+            await descopeClient.Mgmt.V1.Tenant.Settings.GetWithTenantIdAsync(tenantId!);
+        });
+    }
+
+    /// <summary>
+    /// Tests that GetWithLoginIdAndProviderAsync for User Provider Token passes both parameters.
+    /// </summary>
+    [Fact]
+    public async Task UserProviderToken_GetWithLoginIdAndProviderAsync_PassesParametersCorrectly()
+    {
+        // Arrange
+        var testLoginId = "user@example.com";
+        var testProvider = "google";
+
+        var descopeClient = TestDescopeClientFactory.CreateWithAsserter<UserProviderTokenResponse>(
+            requestInfo =>
+            {
+                requestInfo.QueryParameters.Should().ContainKey("loginId", "The login ID should be in query parameters");
+                requestInfo.QueryParameters["loginId"].Should().Be(testLoginId, "The login ID should match");
+                requestInfo.QueryParameters.Should().ContainKey("provider", "The provider should be in query parameters");
+                requestInfo.QueryParameters["provider"].Should().Be(testProvider, "The provider should match");
+                return new UserProviderTokenResponse();
+            });
+
+        // Act
+        await descopeClient.Mgmt.V1.User.Provider.Token.GetWithLoginIdAndProviderAsync(testLoginId, testProvider);
+    }
+
+    /// <summary>
+    /// Tests that GetWithLoginIdAndProviderAsync throws when login ID or provider is missing.
+    /// </summary>
+    [Theory]
+    [InlineData(null, "google")]
+    [InlineData("", "google")]
+    [InlineData("user@example.com", null)]
+    [InlineData("user@example.com", "")]
+    public async Task UserProviderToken_GetWithLoginIdAndProviderAsync_ThrowsDescopeException_WhenParameterIsMissing(string? loginId, string? provider)
+    {
+        // Arrange
+        var descopeClient = TestDescopeClientFactory.CreateWithEmptyResponse();
+
+        // Act & Assert
+        await Assert.ThrowsAsync<DescopeException>(async () =>
+        {
+            await descopeClient.Mgmt.V1.User.Provider.Token.GetWithLoginIdAndProviderAsync(loginId!, provider!);
+        });
+    }
+
+    /// <summary>
+    /// Tests that GetWithIdAsync for Third Party Application Secret passes the ID.
+    /// </summary>
+    [Fact]
+    public async Task ThirdPartyAppSecret_GetWithIdAsync_PassesIdCorrectly()
+    {
+        // Arrange
+        var testId = "test-app-id";
+
+        var descopeClient = TestDescopeClientFactory.CreateWithAsserter<GetThirdPartyApplicationSecretResponse>(
+            requestInfo =>
+            {
+                requestInfo.QueryParameters.Should().ContainKey("id", "The ID should be in query parameters");
+                requestInfo.QueryParameters["id"].Should().Be(testId, "The ID should match");
+                return new GetThirdPartyApplicationSecretResponse();
+            });
+
+        // Act
+        await descopeClient.Mgmt.V1.Thirdparty.App.Secret.GetWithIdAsync(testId);
+    }
+
+    /// <summary>
+    /// Tests that GetWithIdAsync for Third Party Application Secret throws when ID is null or empty.
+    /// </summary>
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    public async Task ThirdPartyAppSecret_GetWithIdAsync_ThrowsDescopeException_WhenIdIsMissing(string? id)
+    {
+        // Arrange
+        var descopeClient = TestDescopeClientFactory.CreateWithEmptyResponse();
+
+        // Act & Assert
+        await Assert.ThrowsAsync<DescopeException>(async () =>
+        {
+            await descopeClient.Mgmt.V1.Thirdparty.App.Secret.GetWithIdAsync(id!);
+        });
+    }
+
+    /// <summary>
     /// Tests that PostWithJsonOutputAsync correctly deserializes flow output to JSON.
     /// </summary>
     [Fact]

--- a/Descope/Sdk/Mgmt/MgmtExtensions.cs
+++ b/Descope/Sdk/Mgmt/MgmtExtensions.cs
@@ -287,6 +287,85 @@ public static class MgmtExtensions
     }
 
     /// <summary>
+    /// Loads tenant settings by tenant ID.
+    /// This is a convenience method that simplifies the common pattern of loading settings for a tenant.
+    /// </summary>
+    /// <param name="requestBuilder">The tenant settings request builder</param>
+    /// <param name="tenantId">The tenant ID</param>
+    /// <param name="cancellationToken">Cancellation token</param>
+    /// <returns>GetTenantSettingsResponse containing the tenant settings information</returns>
+    public static async Task<GetTenantSettingsResponse?> GetWithTenantIdAsync(
+        this Descope.Mgmt.V1.Mgmt.Tenant.Settings.SettingsRequestBuilder requestBuilder,
+        string tenantId,
+        CancellationToken cancellationToken = default)
+    {
+        if (string.IsNullOrEmpty(tenantId))
+        {
+            throw new DescopeException("Tenant ID is required for loading tenant settings");
+        }
+
+        return await requestBuilder.GetAsync(requestConfiguration =>
+        {
+            requestConfiguration.QueryParameters.Id = tenantId;
+        }, cancellationToken: cancellationToken);
+    }
+
+    /// <summary>
+    /// Loads an outbound provider token for a user by login ID and provider.
+    /// This is a convenience method that simplifies the common pattern of fetching a stored provider token.
+    /// </summary>
+    /// <param name="requestBuilder">The user provider token request builder</param>
+    /// <param name="loginId">The user login ID</param>
+    /// <param name="provider">The provider name</param>
+    /// <param name="cancellationToken">Cancellation token</param>
+    /// <returns>UserProviderTokenResponse containing the provider token information</returns>
+    public static async Task<UserProviderTokenResponse?> GetWithLoginIdAndProviderAsync(
+        this Descope.Mgmt.V1.Mgmt.User.Provider.Token.TokenRequestBuilder requestBuilder,
+        string loginId,
+        string provider,
+        CancellationToken cancellationToken = default)
+    {
+        if (string.IsNullOrEmpty(loginId))
+        {
+            throw new DescopeException("Login ID is required for loading a user provider token");
+        }
+        if (string.IsNullOrEmpty(provider))
+        {
+            throw new DescopeException("Provider is required for loading a user provider token");
+        }
+
+        return await requestBuilder.GetAsync(requestConfiguration =>
+        {
+            requestConfiguration.QueryParameters.LoginId = loginId;
+            requestConfiguration.QueryParameters.Provider = provider;
+        }, cancellationToken: cancellationToken);
+    }
+
+    /// <summary>
+    /// Loads a third-party application's secret by ID.
+    /// This is a convenience method that simplifies the common pattern of loading a third-party application secret by its ID.
+    /// </summary>
+    /// <param name="requestBuilder">The third-party app secret request builder</param>
+    /// <param name="id">The third-party application ID</param>
+    /// <param name="cancellationToken">Cancellation token</param>
+    /// <returns>GetThirdPartyApplicationSecretResponse containing the application secret information</returns>
+    public static async Task<GetThirdPartyApplicationSecretResponse?> GetWithIdAsync(
+        this Descope.Mgmt.V1.Mgmt.Thirdparty.App.Secret.SecretRequestBuilder requestBuilder,
+        string id,
+        CancellationToken cancellationToken = default)
+    {
+        if (string.IsNullOrEmpty(id))
+        {
+            throw new DescopeException("ID is required for loading a third-party application secret");
+        }
+
+        return await requestBuilder.GetAsync(requestConfiguration =>
+        {
+            requestConfiguration.QueryParameters.Id = id;
+        }, cancellationToken: cancellationToken);
+    }
+
+    /// <summary>
     /// Runs a management flow with JSON output deserialization.
     /// This extension method wraps the generated PostAsync method and provides convenient access
     /// to flow output data as a JsonDocument, avoiding the need to manually work with UntypedObject types.

--- a/Obsolete.csv
+++ b/Obsolete.csv
@@ -8,6 +8,9 @@ Descope/Generated/Mgmt/V2/Mgmt/Sso/Settings/SettingsRequestBuilder.cs,GetAsync,G
 Descope/Generated/Mgmt/V1/Mgmt/Thirdparty/App/Load/LoadRequestBuilder.cs,GetAsync,GetWithIdAsync or GetWithClientIdAsync
 Descope/Generated/Mgmt/V1/Mgmt/Sso/Settings/SettingsRequestBuilder.cs,DeleteAsync,DeleteWithTenantIdAsync
 Descope/Generated/Mgmt/V1/Mgmt/Tenant/TenantRequestBuilder.cs,GetAsync,GetWithIdAsync
+Descope/Generated/Mgmt/V1/Mgmt/Tenant/Settings/SettingsRequestBuilder.cs,GetAsync,GetWithTenantIdAsync
+Descope/Generated/Mgmt/V1/Mgmt/User/Provider/Token/TokenRequestBuilder.cs,GetAsync,GetWithLoginIdAndProviderAsync
+Descope/Generated/Mgmt/V1/Mgmt/Thirdparty/App/Secret/SecretRequestBuilder.cs,GetAsync,GetWithIdAsync
 Descope/Generated/Auth/V1/Auth/Magiclink/Update/Email/EmailRequestBuilder.cs,PostAsync,PostWithJwtAsync
 Descope/Generated/Auth/V1/Auth/Magiclink/Update/Phone/Sms/SmsRequestBuilder.cs,PostAsync,PostWithJwtAsync
 Descope/Generated/Auth/V1/Auth/Magiclink/Update/Phone/Whatsapp/WhatsappRequestBuilder.cs,PostAsync,PostWithJwtAsync

--- a/README.md
+++ b/README.md
@@ -122,6 +122,30 @@ var count = root.GetProperty("obj").GetProperty("count").GetInt32();
 var enabled = root.GetProperty("obj").GetProperty("enabled").GetBoolean();
 ```
 
+### Management Convenience Methods
+
+Every management endpoint is available directly on the generated `client.Mgmt.V1` / `client.Mgmt.V2` request builders. For common lookups that require a query parameter, the SDK adds extension methods that make the required inputs explicit:
+
+```csharp
+// Load by identifier / ID
+var user      = await client.Mgmt.V1.User.GetWithIdentifierAsync("user@example.com");
+var tenant    = await client.Mgmt.V1.Tenant.GetWithIdAsync("tenant-id");
+var accessKey = await client.Mgmt.V1.Accesskey.GetWithIdAsync("key-id");
+var ssoApp    = await client.Mgmt.V1.Sso.Idp.App.Load.GetWithIdAsync("app-id");
+var tpApp     = await client.Mgmt.V1.Thirdparty.App.Load.GetWithIdAsync("app-id");
+var tpAppByClient = await client.Mgmt.V1.Thirdparty.App.Load.GetWithClientIdAsync("client-id");
+
+// Settings lookups
+var tenantSettings = await client.Mgmt.V1.Tenant.Settings.GetWithTenantIdAsync("tenant-id");
+var pwdSettings    = await client.Mgmt.V1.Password.Settings.GetWithTenantIdAsync("tenant-id");
+var projectPwd     = await client.Mgmt.V1.Password.Settings.GetForProjectAsync();
+var ssoSettings    = await client.Mgmt.V2.Sso.Settings.GetWithTenantIdAsync("tenant-id");
+
+// Outbound provider token + third-party app secret
+var providerToken = await client.Mgmt.V1.User.Provider.Token.GetWithLoginIdAndProviderAsync("user@example.com", "google");
+var appSecret     = await client.Mgmt.V1.Thirdparty.App.Secret.GetWithIdAsync("app-id");
+```
+
 ## Token Validation
 
 The SDK provides three methods for working with session tokens:


### PR DESCRIPTION
Fixes descope/etc#16608

[View workflow run](https://github.com/descope/shuni/actions/runs/28678019610)

Done. Here's what I found and did.

## Finding: endpoint parity already exists

The .NET SDK is **Kiota-generated from the same OpenAPI specs** the backend serves. Every Go SDK management area — Tenant, User, AccessKey, SSO, Permission, Role, Group, Flow, Project, Audit, Authz/FGA, JWT, Connector, Outbound, Password, Theme, Third-party, etc. — **already exists** as a generated request builder under `client.Mgmt.V1.*` / `V2.*`. So endpoint-level parity is automatic; there are no "missing endpoints" to add.

The genuine gap is the **ergonomic wrapper layer**: for GET lookups that need a query parameter, the SDK hand-writes `GetWith…Async` helpers (and marks the raw generated method obsolete). I diffed the generated GET-by-query-param builders against the existing wrappers and found three that were missing but map directly to Go SDK methods.

## Changes

- **`Descope/Sdk/Mgmt/MgmtExtensions.cs`** — added three wrappers following the existing pattern:
  - `Tenant.Settings.GetWithTenantIdAsync` → Go `Tenant.GetSettings`
  - `User.Provider.Token.GetWithLoginIdAndProviderAsync` → Go `User.GetProviderToken`
  - `Thirdparty.App.Secret.GetWithIdAsync` → third-party app secret fetch
- **`Obsolete.csv`** — marked the three wrapped generated `GetAsync` methods obsolete (per CLAUDE.md contract).
- **`README.md`** — new "Management Convenience Methods" section documenting the full set of lookup helpers, including the new ones.
- **`MgmtExtensionsTests.cs`** — pass-through + validation tests for all three (build green, 42/42 pass).

`skipped:` I did **not** blanket-add wrappers for every POST/list endpoint — those already work cleanly on the generated builders without an ergonomic gap. `add when` a specific endpoint's raw call proves awkward enough to warrant a helper (the pattern + Obsolete.csv entry is now well-established for the next one).

Ephemeral `mise.toml` (created to install dotnet) was removed — repo left clean, only the four intended files changed.

---
*Created by [Shuni](https://github.com/descope/shuni) 🐕*