### PR TITLE
fix(di): singleton IDescopeClient to persist JWKS cache (+ build/CI fixes)

### DIFF
--- a/Descope.Test/IntegrationTests/Management/UserTests.cs
+++ b/Descope.Test/IntegrationTests/Management/UserTests.cs
@@ -1440,12 +1440,12 @@ namespace Descope.Test.Integration
                     Text = name,
                     Limit = 1
                 };
-                var users = await _descopeClient.Mgmt.V2.User.Search.PostAsync(searchByNameRequest);
-                Assert.NotNull(users?.Users);
-                Assert.Single(users.Users);
-                users = await _descopeClient.Mgmt.V2.User.Search.PostAsync(searchByNameRequest);
-                Assert.NotNull(users?.Users);
-                Assert.Single(users.Users);
+                await RetryUntilSuccessAsync(async () =>
+                {
+                    var users = await _descopeClient.Mgmt.V2.User.Search.PostAsync(searchByNameRequest);
+                    Assert.NotNull(users?.Users);
+                    Assert.Single(users.Users);
+                });
 
                 var searchByTenantRoles = new SearchUsersRequest
                 {
@@ -1453,31 +1453,31 @@ namespace Descope.Test.Integration
                     TenantIds = new List<string> { tenantId! },
                     RoleNames = new List<string> { roleName! }
                 };
-                users = await _descopeClient.Mgmt.V2.User.Search.PostAsync(searchByTenantRoles);
-                Assert.NotNull(users?.Users);
-                Assert.Single(users.Users);
-                users = await _descopeClient.Mgmt.V2.User.Search.PostAsync(searchByTenantRoles);
-                Assert.NotNull(users?.Users);
-                Assert.Single(users.Users);
+                await RetryUntilSuccessAsync(async () =>
+                {
+                    var users = await _descopeClient.Mgmt.V2.User.Search.PostAsync(searchByTenantRoles);
+                    Assert.NotNull(users?.Users);
+                    Assert.Single(users.Users);
+                });
 
                 // Delete user
                 await _descopeClient.Mgmt.V1.User.DeletePath.PostAsync(new DeleteUserRequest { Identifier = loginId });
                 loginId = null;
 
                 // Search again by name - should be empty
-                users = await _descopeClient.Mgmt.V2.User.Search.PostAsync(searchByNameRequest);
-                Assert.NotNull(users?.Users);
-                Assert.Empty(users.Users);
-                users = await _descopeClient.Mgmt.V2.User.Search.PostAsync(searchByNameRequest);
-                Assert.NotNull(users?.Users);
-                Assert.Empty(users.Users);
+                await RetryUntilSuccessAsync(async () =>
+                {
+                    var users = await _descopeClient.Mgmt.V2.User.Search.PostAsync(searchByNameRequest);
+                    Assert.NotNull(users?.Users);
+                    Assert.Empty(users.Users);
+                });
 
-                users = await _descopeClient.Mgmt.V2.User.Search.PostAsync(searchByTenantRoles);
-                Assert.NotNull(users?.Users);
-                Assert.Empty(users.Users);
-                users = await _descopeClient.Mgmt.V2.User.Search.PostAsync(searchByTenantRoles);
-                Assert.NotNull(users?.Users);
-                Assert.Empty(users.Users);
+                await RetryUntilSuccessAsync(async () =>
+                {
+                    var users = await _descopeClient.Mgmt.V2.User.Search.PostAsync(searchByTenantRoles);
+                    Assert.NotNull(users?.Users);
+                    Assert.Empty(users.Users);
+                });
             }
             finally
             {

--- a/Descope.Test/UnitTests/Factories/DescopeServiceCollectionExtensionsTests.cs
+++ b/Descope.Test/UnitTests/Factories/DescopeServiceCollectionExtensionsTests.cs
@@ -1,3 +1,5 @@
+using System.Net;
+using System.Text;
 using Descope;
 using Microsoft.Extensions.DependencyInjection;
 using Xunit;
@@ -184,5 +186,74 @@ public class DescopeServiceCollectionExtensionsTests
         // Assert
         var client = serviceProvider.GetService<IDescopeClient>();
         Assert.NotNull(client);
+    }
+
+    // JWT header {"alg":"RS256","kid":"test-key","typ":"JWT"} — kid matches the stub key.
+    private const string TestJwt = "eyJhbGciOiJSUzI1NiIsImtpZCI6InRlc3Qta2V5IiwidHlwIjoiSldUIn0.eyJpc3MiOiJ0ZXN0IiwiZXhwIjoyMTQ3NDgzNjQ3fQ.test";
+
+    // descope/etc#16677: JWKS cache must survive DI scopes, so two scopes fetch keys once, not twice.
+    [Fact]
+    public async Task AddDescopeClient_ValidateSessionAcrossScopes_FetchesKeysOnce()
+    {
+        // Arrange
+        var keysFetchCount = 0;
+        var services = new ServiceCollection();
+        var options = new DescopeClientOptions
+        {
+            ProjectId = "test_project_id",
+            ManagementKey = "test_management_key",
+            BaseUrl = "https://api.descope.com"
+        };
+        services.AddDescopeClient(options);
+
+        // Last ConfigurePrimaryHttpMessageHandler wins, placing this counting JWKS stub under the SDK pipeline.
+        services.AddHttpClient("DescopeClient")
+            .ConfigurePrimaryHttpMessageHandler(
+                () => new CountingJwksHandler(() => Interlocked.Increment(ref keysFetchCount)));
+
+        var serviceProvider = services.BuildServiceProvider();
+
+        // Act — two separate DI scopes simulate two HTTP requests
+        using (var scope1 = serviceProvider.CreateScope())
+        {
+            var client1 = scope1.ServiceProvider.GetRequiredService<IDescopeClient>();
+            try { await client1.Auth.ValidateSessionAsync(TestJwt); } catch (DescopeException) { }
+        }
+
+        using (var scope2 = serviceProvider.CreateScope())
+        {
+            var client2 = scope2.ServiceProvider.GetRequiredService<IDescopeClient>();
+            try { await client2.Auth.ValidateSessionAsync(TestJwt); } catch (DescopeException) { }
+        }
+
+        // Assert — cache shared across scopes: keys endpoint hit once, not once per scope
+        Assert.Equal(1, keysFetchCount);
+    }
+
+    // Primary handler stub: counts calls to the keys endpoint and returns a static JWKS payload.
+    private sealed class CountingJwksHandler : HttpMessageHandler
+    {
+        // Valid RSA modulus (base64url) so key import in JwtValidator.FetchKeys succeeds.
+        private const string KeyModulus = "xGOr-H7A-PWc8GG8-lJg_7Jc9J8sB1pP8tTlv3PcQzD9Kc4z_1S_h9LHPh-6fYtZ7X8_1TZY8VkBL1Rh-4tD_Y9J1tK5_5FZz4E0O8Y4y9t3y0_5sZ4E8z3t_4K9y1t5z4K1y3t8z2E4y9t5z4E1y3t8z2K4y9t5z4K1y3t8z2E4y9t5z4E1y3t8z2K4y9t";
+
+        private readonly Action _onKeysFetch;
+
+        public CountingJwksHandler(Action onKeysFetch) => _onKeysFetch = onKeysFetch;
+
+        protected override Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            if (request.RequestUri!.AbsolutePath.Contains("/v2/keys/"))
+            {
+                _onKeysFetch();
+            }
+
+            var json = "{\"keys\":[{\"alg\":\"RS256\",\"e\":\"AQAB\",\"kid\":\"test-key\",\"kty\":\"RSA\",\"use\":\"sig\",\"n\":\""
+                + KeyModulus + "\"}]}";
+            return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent(json, Encoding.UTF8, "application/json")
+            });
+        }
     }
 }

--- a/Descope/Sdk/Factories/DescopeServiceCollectionExtensions.cs
+++ b/Descope/Sdk/Factories/DescopeServiceCollectionExtensions.cs
@@ -78,8 +78,8 @@ public static class DescopeServiceCollectionExtensions
             return handler;
         });
 
-        // Create and register the Descope Client Service
-        services.AddScoped<IDescopeClient>(sp =>
+        // Singleton so the JwtValidator's JWKS cache is shared across DI scopes (descope/etc#16677).
+        services.AddSingleton<IDescopeClient>(sp =>
         {
             // Create HttpClients from factory
             // Separate HttpClient instances are needed to avoid cross contamination of http handlers, which most likely happens due to internal Kiota implementation details

--- a/Descope/Sdk/Factories/DescopeServiceCollectionExtensions.cs
+++ b/Descope/Sdk/Factories/DescopeServiceCollectionExtensions.cs
@@ -78,7 +78,7 @@ public static class DescopeServiceCollectionExtensions
             return handler;
         });
 
-        // Singleton so the JwtValidator's JWKS cache is shared across DI scopes (descope/etc#16677).
+        // Create and register the Descope Client Service Singleton
         services.AddSingleton<IDescopeClient>(sp =>
         {
             // Create HttpClients from factory

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@
 .DEFAULT_GOAL := build
 
 # Management API OpenAPI spec file location
-MGMT_OPENAPI_SPEC := $(GODESCOPE)/managementservice/pkg/managementservice/proto/v1/doc/management.openapi.yaml
+MGMT_OPENAPI_SPEC := $(GODESCOPE)/backend/managementservice/pkg/managementservice/proto/v1/doc/management.openapi.yaml
 
 # Management API Kiota generation parameters
 MGMT_KIOTA_LANG := CSharp
@@ -14,7 +14,7 @@ MGMT_KIOTA_OUTPUT := ./Descope/Generated/Mgmt
 # Exclude paths are defined in the command itself, to allow supporting multiple excludes
 
 # Auth API OpenAPI spec file location
-AUTH_OPENAPI_SPEC := $(GODESCOPE)/onetimeservice/pkg/onetimeservice/proto/v1/doc/onetime.openapi.yaml
+AUTH_OPENAPI_SPEC := $(GODESCOPE)/backend/onetimeservice/pkg/onetimeservice/proto/v1/doc/onetime.openapi.yaml
 
 # Auth API Kiota generation parameters
 AUTH_KIOTA_LANG := CSharp


### PR DESCRIPTION
## Related Issues
Fixes: https://github.com/descope/etc/issues/16677

## In a Nutshell
- Register `IDescopeClient` as **singleton** instead of scoped — JWKS cache now shared across DI scopes (requests)
- **Build fix:** correct Makefile OpenAPI spec paths to the `descope/backend` monorepo
- **CI fix:** stabilize flaky `User_DeleteAndSearch` integration test via the existing retry helper

## Description
`AddDescopeClient` registered `IDescopeClient` with `AddScoped`, so in ASP.NET Core every request built a new `DescopeClient` → new `JwtValidator` with an empty JWKS cache, re-fetching `GET /v2/keys/{projectId}` on every request. Switched to `AddSingleton`: `DescopeClient` is thread-safe, not `IDisposable`, and captures only `IHttpClientFactory` (itself singleton), so the singleton lifetime is safe and lets the 5-minute key cache actually persist. Consistent with the non-DI `DescopeManagementClientFactory`, which already holds a long-lived client.

### Unrelated build issues fixed while validating this PR
- **Makefile spec paths** — `MGMT_OPENAPI_SPEC` / `AUTH_OPENAPI_SPEC` now point at `$(GODESCOPE)/backend/<service>/...` (previously `make` failed locally with "OpenAPI spec file not found").
- **Flaky integration test** — `User_DeleteAndSearch` asserted on user search immediately after create/delete with no retry, so search-index lag intermittently failed it (and was the recurring red CI check). Wrapped those searches in the existing `RetryUntilSuccessAsync` helper, matching sibling tests.

## Must
- [x] Tests
- [ ] Documentation (if applicable)

🤖 Generated with [Claude Code](https://claude.com/claude-code)