### PR TITLE
feat: make JWKS cache duration configurable via DescopeClientOptions

### DIFF
--- a/Descope.Test/UnitTests/Authentication/JwtValidatorCachingTests.cs
+++ b/Descope.Test/UnitTests/Authentication/JwtValidatorCachingTests.cs
@@ -157,7 +157,7 @@ public class JwtValidatorCachingTests
             "test_project_id",
             "https://api.descope.com",
             new HttpClient(mockHandler.Object),
-            () => fakeNow);
+            timeProvider: () => fakeNow);
 
         // Act: first validation — fetches keys
         try { await validator.ValidateToken(TestJwt); } catch (DescopeException) { }
@@ -175,6 +175,40 @@ public class JwtValidatorCachingTests
         Assert.Equal(2, requestCount);
 
         // Next call within new TTL window — no further re-fetch
+        try { await validator.ValidateToken(TestJwt); } catch (DescopeException) { }
+        Assert.Equal(2, requestCount);
+    }
+
+    [Fact]
+    public async Task ValidateToken_CustomKeyRefreshInterval_ShouldRespectConfiguredTtl()
+    {
+        // Arrange
+        var requestCount = 0;
+        var mockHandler = CreateMockHttpHandler((request, count) =>
+        {
+            requestCount = count;
+            return CreateJwksResponse(); // always returns "test-key", matching TestJwt
+        });
+
+        var fakeNow = DateTimeOffset.UtcNow;
+        var validator = new JwtValidator(
+            "test_project_id",
+            "https://api.descope.com",
+            new HttpClient(mockHandler.Object),
+            keyRefreshInterval: TimeSpan.FromMinutes(30),
+            timeProvider: () => fakeNow);
+
+        // Act: first validation — fetches keys
+        try { await validator.ValidateToken(TestJwt); } catch (DescopeException) { }
+        Assert.Equal(1, requestCount);
+
+        // Past the default 5-minute TTL but within the configured 30-minute TTL — no re-fetch
+        fakeNow = fakeNow.AddMinutes(10);
+        try { await validator.ValidateToken(TestJwt); } catch (DescopeException) { }
+        Assert.Equal(1, requestCount);
+
+        // Past the configured 30-minute TTL — should re-fetch
+        fakeNow = fakeNow.AddMinutes(21);
         try { await validator.ValidateToken(TestJwt); } catch (DescopeException) { }
         Assert.Equal(2, requestCount);
     }

--- a/Descope.Test/UnitTests/DescopeClientOptionsTests.cs
+++ b/Descope.Test/UnitTests/DescopeClientOptionsTests.cs
@@ -79,6 +79,47 @@ public class DescopeClientOptionsTests
         Assert.Contains("ProjectId is required", exception.Message);
     }
 
+    [Fact]
+    public void JwksCacheDuration_DefaultsToFiveMinutes()
+    {
+        // Arrange & Act
+        var options = new DescopeClientOptions();
+
+        // Assert
+        Assert.Equal(TimeSpan.FromMinutes(5), options.JwksCacheDuration);
+    }
+
+    [Fact]
+    public void Validate_WithCustomJwksCacheDuration_DoesNotThrow()
+    {
+        // Arrange
+        var options = new DescopeClientOptions
+        {
+            ProjectId = "test_project_id",
+            JwksCacheDuration = TimeSpan.FromMinutes(30)
+        };
+
+        // Act & Assert
+        options.Validate(); // Should not throw
+    }
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(-1)]
+    public void Validate_WithNonPositiveJwksCacheDuration_ThrowsDescopeException(int minutes)
+    {
+        // Arrange
+        var options = new DescopeClientOptions
+        {
+            ProjectId = "test_project_id",
+            JwksCacheDuration = TimeSpan.FromMinutes(minutes)
+        };
+
+        // Act & Assert
+        var exception = Assert.Throws<DescopeException>(() => options.Validate());
+        Assert.Contains("JwksCacheDuration must be greater than zero", exception.Message);
+    }
+
     [Theory]
     [InlineData("https://cache.example.com")]
     [InlineData("http://192.168.1.1:8080")]

--- a/Descope/Sdk/Auth/JwtValidator.cs
+++ b/Descope/Sdk/Auth/JwtValidator.cs
@@ -19,15 +19,16 @@ internal class JwtValidator
     private readonly HttpClient _httpClient;
     private readonly string _baseUrl;
     private readonly SemaphoreSlim _fetchSemaphore = new(1, 1);
-    private readonly TimeSpan _keyRefreshInterval = TimeSpan.FromMinutes(5);
+    private readonly TimeSpan _keyRefreshInterval;
     private long _lastKeyFetchTicks = 0;
     private readonly Func<DateTimeOffset> _timeProvider;
 
-    public JwtValidator(string projectId, string baseUrl, HttpClient httpClient, Func<DateTimeOffset>? timeProvider = null)
+    public JwtValidator(string projectId, string baseUrl, HttpClient httpClient, TimeSpan? keyRefreshInterval = null, Func<DateTimeOffset>? timeProvider = null)
     {
         _projectId = projectId ?? throw new ArgumentNullException(nameof(projectId));
         _baseUrl = baseUrl ?? throw new ArgumentNullException(nameof(baseUrl));
         _httpClient = httpClient ?? throw new ArgumentNullException(nameof(httpClient));
+        _keyRefreshInterval = keyRefreshInterval ?? TimeSpan.FromMinutes(5);
         _timeProvider = timeProvider ?? (() => DateTimeOffset.UtcNow);
     }
 

--- a/Descope/Sdk/DescopeClient.cs
+++ b/Descope/Sdk/DescopeClient.cs
@@ -20,15 +20,17 @@ public class DescopeClient : IDescopeClient
     /// <param name="projectId">The Descope project ID.</param>
     /// <param name="baseUrl">The base URL for the Descope API.</param>
     /// <param name="fetchKeysHttpClient">An HttpClient to fetch public keys, needed for JWT validation.</param>
+    /// <param name="jwksCacheDuration">How long fetched public signing keys are cached before the next validation triggers a refresh. Defaults to 5 minutes when null.</param>
     internal DescopeClient(
         DescopeMgmtKiotaClient mgmtKiotaClient,
         DescopeAuthKiotaClient authKiotaClient,
         string projectId,
         string baseUrl,
-        HttpClient fetchKeysHttpClient)
+        HttpClient fetchKeysHttpClient,
+        TimeSpan? jwksCacheDuration = null)
     {
         _mgmtClient = new DescopeMgmtClient(mgmtKiotaClient);
-        _authClient = new DescopeAuthClient(authKiotaClient, projectId, baseUrl, fetchKeysHttpClient);
+        _authClient = new DescopeAuthClient(authKiotaClient, projectId, baseUrl, fetchKeysHttpClient, jwksCacheDuration);
     }
 
     public class DescopeMgmtClient
@@ -54,10 +56,11 @@ public class DescopeClient : IDescopeClient
             DescopeAuthKiotaClient authKiotaClient,
             string projectId,
             string baseUrl,
-            HttpClient fetchKeysHttpClient)
+            HttpClient fetchKeysHttpClient,
+            TimeSpan? jwksCacheDuration = null)
         {
             _authKiotaClient = authKiotaClient;
-            var jwtValidator = new JwtValidator(projectId, baseUrl, fetchKeysHttpClient);
+            var jwtValidator = new JwtValidator(projectId, baseUrl, fetchKeysHttpClient, jwksCacheDuration);
             _tokenActions = new TokenActions(jwtValidator, authKiotaClient.V1.Auth);
         }
 

--- a/Descope/Sdk/DescopeClientOptions.cs
+++ b/Descope/Sdk/DescopeClientOptions.cs
@@ -52,6 +52,20 @@ public class DescopeClientOptions
     public bool IsUnsafe { get; set; } = false;
 
     /// <summary>
+    /// How long the public signing keys (JWKS) fetched from <c>/v2/keys/{projectId}</c>
+    /// are cached before the next session validation triggers a refresh.
+    /// Increasing this reduces the number of key-fetch requests for high-traffic services.
+    /// Default: 5 minutes.
+    /// </summary>
+    /// <remarks>
+    /// Raising this value is safe even during key rotation: session validation performs an
+    /// immediate key re-fetch (bypassing this TTL) whenever a token is signed with a key ID
+    /// that is not already cached, so tokens from newly rotated keys are still accepted right away.
+    /// Must be greater than zero.
+    /// </remarks>
+    public TimeSpan JwksCacheDuration { get; set; } = TimeSpan.FromMinutes(5);
+
+    /// <summary>
     /// Validates that required options are set.
     /// </summary>
     public void Validate()
@@ -59,6 +73,11 @@ public class DescopeClientOptions
         if (string.IsNullOrWhiteSpace(ProjectId))
         {
             throw new DescopeException("ProjectId is required");
+        }
+
+        if (JwksCacheDuration <= TimeSpan.Zero)
+        {
+            throw new DescopeException("JwksCacheDuration must be greater than zero");
         }
 
         if (!string.IsNullOrWhiteSpace(FgaCacheUrl))

--- a/Descope/Sdk/Factories/DescopeClientFactory.cs
+++ b/Descope/Sdk/Factories/DescopeClientFactory.cs
@@ -58,7 +58,7 @@ public static class DescopeManagementClientFactory
         var authClient = new DescopeAuthKiotaClient(authAdapter);
 
         // Wrap both clients with JWT validation support
-        return new DescopeClient(mgmtClient, authClient, options.ProjectId, options.BaseUrl!, fetchKeysHttpClient);
+        return new DescopeClient(mgmtClient, authClient, options.ProjectId, options.BaseUrl!, fetchKeysHttpClient, options.JwksCacheDuration);
     }
 
     private static HttpClient CreateDescopeHttpClient(string projectId, bool isUnsafe, string? fgaCacheUrl)
@@ -149,6 +149,6 @@ public static class DescopeManagementClientFactory
         var mgmtKiotaClient = new DescopeMgmtKiotaClient(mgmtAdapter);
 
         // Create and return the wrapper client with optional HttpClient for HTTP-level testing
-        return new DescopeClient(mgmtKiotaClient, authKiotaClient, options.ProjectId, options.BaseUrl!, httpClient);
+        return new DescopeClient(mgmtKiotaClient, authKiotaClient, options.ProjectId, options.BaseUrl!, httpClient, options.JwksCacheDuration);
     }
 }

--- a/Descope/Sdk/Factories/DescopeServiceCollectionExtensions.cs
+++ b/Descope/Sdk/Factories/DescopeServiceCollectionExtensions.cs
@@ -104,7 +104,7 @@ public static class DescopeServiceCollectionExtensions
             var authClient = new DescopeAuthKiotaClient(authAdapter);
 
             // Create the wrapper client with internal Kiota clients
-            return new DescopeClient(mgmtClient, authClient, options.ProjectId, options.BaseUrl!, fetchKeysHttpClient);
+            return new DescopeClient(mgmtClient, authClient, options.ProjectId, options.BaseUrl!, fetchKeysHttpClient, options.JwksCacheDuration);
         });
 
         return services;

--- a/README.md
+++ b/README.md
@@ -20,7 +20,8 @@ var options = new DescopeClientOptions
     AuthManagementKey = "your-auth-key",     // Optional, for accessing disabled auth APIs
     BaseUrl = "https://api.descope.com",     // Optional, auto-detected from project ID
     FgaCacheUrl = "https://fga.example.com", // Optional, if using the Descope FGA Cache Docker Container
-    IsUnsafe = false                         // Optional, for dev/test only
+    IsUnsafe = false,                        // Optional, for dev/test only
+    JwksCacheDuration = TimeSpan.FromMinutes(5) // Optional, how long public signing keys are cached (default: 5 minutes)
 };
 ```
 
@@ -128,12 +129,28 @@ The SDK provides three methods for working with session tokens:
 
 ### ValidateSessionAsync
 
-Validates a session JWT **locally** using cached public keys. The public key is fetched from the server only once and then cached for subsequent validations.
+Validates a session JWT **locally** using cached public keys. The public signing keys (JWKS) are fetched from the server and cached, so most validations do not make a network call.
 
 ```csharp
 var token = await client.Auth.ValidateSessionAsync(sessionJwt);
 // Returns Token with claims, subject, expiration, etc.
 ```
+
+#### Public key (JWKS) caching
+
+Fetched keys are cached for `DescopeClientOptions.JwksCacheDuration` (default **5 minutes**). Once the duration elapses, the next validation refreshes the keys; refreshes are lazy (triggered on the next validation), not on a background timer. To reduce key-fetch requests on high-traffic services, increase the duration:
+
+```csharp
+var options = new DescopeClientOptions
+{
+    ProjectId = "your-project-id",
+    JwksCacheDuration = TimeSpan.FromMinutes(30)
+};
+```
+
+Raising this value is safe even during key rotation: if a token is signed with a key ID that is not already cached, the SDK performs an immediate key re-fetch (bypassing the cache duration) and retries validation once, so tokens from newly rotated keys are accepted right away. `JwksCacheDuration` must be greater than zero.
+
+> **Note:** For the cache to persist across requests, reuse a single `IDescopeClient` instance. The DI registration (`AddDescopeClient`) registers it as a singleton for you.
 
 ### RefreshSessionAsync
 


### PR DESCRIPTION
Fixes https://github.com/descope/etc/issues/16953

## Summary

Makes the JWKS (public signing key) cache TTL configurable. It was hardcoded to 5 minutes in `JwtValidator`, so high-traffic services had no way to reduce key-fetch requests to `/v2/keys/{projectId}`.

Adds `DescopeClientOptions.JwksCacheDuration` (default **5 minutes**, so existing behavior is unchanged) and threads it through both creation paths (factory + DI) into `JwtValidator`.

Context: follow-up to the 1.7.1 singleton-client fix (#230). A customer asked whether the ~5-minute re-fetch cadence is expected (it is) and whether the TTL can be extended (previously no — now yes).

## Changes

- `DescopeClientOptions.JwksCacheDuration` — new optional property with XML docs; `Validate()` rejects non-positive values.
- `JwtValidator` — cache interval is now a constructor parameter (defaults to 5 min).
- Wired through `DescopeClient` → `DescopeAuthClient` → `JwtValidator`, in both `DescopeClientFactory` and `DescopeServiceCollectionExtensions`.
- README: documented the option + JWKS caching behavior; corrected the stale "fetched only once" wording in the `ValidateSessionAsync` section.

## Backwards compatibility

- **Purely additive public API.** The only public change is the new `JwksCacheDuration` property. All modified constructors are `internal` (visible only to `Descope.Test` via `InternalsVisibleTo`).
- **Default behavior unchanged** — defaults to `TimeSpan.FromMinutes(5)`.
- **No previously-valid config breaks** — the new validation only rejects `<= 0`, which was previously unrepresentable.
- Compiles cleanly on all TFMs (netstandard2.0 → net10.0).

## Key-rotation safety

Raising the duration is safe: the existing cache-miss immediate re-fetch bypasses the TTL when a token's `kid` is not cached, so tokens signed with newly rotated keys are accepted immediately regardless of `JwksCacheDuration`.

## Testing

- New unit tests: custom-TTL refresh behavior in `JwtValidatorCachingTests`; default value + validation in `DescopeClientOptionsTests`.
- All 249 unit tests pass.

## Usage

```csharp
services.AddDescopeClient(new DescopeClientOptions
{
    ProjectId = "your-project-id",
    JwksCacheDuration = TimeSpan.FromMinutes(30) // was hardcoded to 5
});
```

## Release

The `feat:` title bumps the minor version (1.7.1 → 1.8.0) via release-please once this squash-merges to `main`. Merging release-please's follow-up release PR cuts the GitHub release and publishes to NuGet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)