### PR TITLE
feat(auth): add PostWithJwtAsync for LogoutAll

### DIFF
--- a/Descope.Test/UnitTests/Authentication/LogoutTests.cs
+++ b/Descope.Test/UnitTests/Authentication/LogoutTests.cs
@@ -1,0 +1,87 @@
+using Descope.Auth.Models.Onetimev1;
+using Descope.Test.Helpers;
+using FluentAssertions;
+using Microsoft.Kiota.Abstractions;
+using Xunit;
+
+namespace Descope.Test.UnitTests.Authentication;
+
+/// <summary>
+/// Unit tests for the logout extension methods, which require a refresh JWT to be passed explicitly.
+/// These tests use a mock request adapter to simulate API responses without making actual HTTP calls.
+/// </summary>
+public class LogoutTests
+{
+    private const string TestRefreshJwt = "test_refresh_jwt";
+
+    /// <summary>
+    /// Tests that Logout sends the refresh JWT along with the request to the expected endpoint.
+    /// </summary>
+    [Fact]
+    public async Task Logout_PostWithJwt_SendsRefreshJwt()
+    {
+        // Arrange
+        var mockResponse = new JWTResponse();
+        var descopeClient = TestDescopeClientFactory.CreateWithAsserter<LogoutRequest, JWTResponse>((requestInfo, requestBody) =>
+        {
+            requestInfo.HttpMethod.Should().Be(Method.POST);
+            requestInfo.URI.AbsolutePath.Should().EndWith("/v1/auth/logout");
+            AssertJwtOption(requestInfo, TestRefreshJwt);
+            return mockResponse;
+        });
+
+        // Act
+        var response = await descopeClient.Auth.V1.Logout.PostWithJwtAsync(new LogoutRequest(), TestRefreshJwt);
+
+        // Assert
+        response.Should().NotBeNull();
+    }
+
+    /// <summary>
+    /// Tests that LogoutAll sends the refresh JWT along with the request to the expected endpoint.
+    /// </summary>
+    [Fact]
+    public async Task LogoutAll_PostWithJwt_SendsRefreshJwt()
+    {
+        // Arrange
+        var mockResponse = new JWTResponse();
+        var descopeClient = TestDescopeClientFactory.CreateWithAsserter<LogoutRequest, JWTResponse>((requestInfo, requestBody) =>
+        {
+            requestInfo.HttpMethod.Should().Be(Method.POST);
+            requestInfo.URI.AbsolutePath.Should().EndWith("/v1/auth/logoutall");
+            AssertJwtOption(requestInfo, TestRefreshJwt);
+            return mockResponse;
+        });
+
+        // Act
+        var response = await descopeClient.Auth.V1.Logoutall.PostWithJwtAsync(new LogoutRequest(), TestRefreshJwt);
+
+        // Assert
+        response.Should().NotBeNull();
+    }
+
+    /// <summary>
+    /// Tests that LogoutAll rejects a missing refresh JWT before issuing a request.
+    /// </summary>
+    [Theory]
+    [InlineData("")]
+    [InlineData(null)]
+    public async Task LogoutAll_PostWithJwt_ThrowsWhenRefreshJwtMissing(string? refreshJwt)
+    {
+        // Arrange
+        var descopeClient = TestDescopeClientFactory.CreateWithResponse(new JWTResponse());
+
+        // Act
+        Func<Task> act = () => descopeClient.Auth.V1.Logoutall.PostWithJwtAsync(new LogoutRequest(), refreshJwt!);
+
+        // Assert
+        await act.Should().ThrowAsync<DescopeException>();
+    }
+
+    private static void AssertJwtOption(RequestInformation requestInfo, string expectedJwt)
+    {
+        var jwtOption = requestInfo.RequestOptions.OfType<DescopeJwtOption>().SingleOrDefault();
+        jwtOption.Should().NotBeNull();
+        jwtOption!.GetContext()["jwt"].Should().Be(expectedJwt);
+    }
+}

--- a/Descope/Generated/Auth/V1/Auth/Logoutall/LogoutallRequestBuilder.cs
+++ b/Descope/Generated/Auth/V1/Auth/Logoutall/LogoutallRequestBuilder.cs
@@ -42,10 +42,12 @@ namespace Descope.Auth.V1.Auth.Logoutall
         /// <param name="requestConfiguration">Configuration for the request such as headers, query parameters, and middleware options.</param>
 #if NETSTANDARD2_1_OR_GREATER || NETCOREAPP3_1_OR_GREATER
 #nullable enable
+        [Obsolete("Use PostWithJwtAsync instead")]
         public async Task<global::Descope.Auth.Models.Onetimev1.JWTResponse?> PostAsync(global::Descope.Auth.Models.Onetimev1.LogoutRequest body, Action<RequestConfiguration<DefaultQueryParameters>>? requestConfiguration = default, CancellationToken cancellationToken = default)
         {
 #nullable restore
 #else
+        [Obsolete("Use PostWithJwtAsync instead")]
         public async Task<global::Descope.Auth.Models.Onetimev1.JWTResponse> PostAsync(global::Descope.Auth.Models.Onetimev1.LogoutRequest body, Action<RequestConfiguration<DefaultQueryParameters>> requestConfiguration = default, CancellationToken cancellationToken = default)
         {
 #endif

--- a/Descope/Sdk/Auth/AuthExtensions.cs
+++ b/Descope/Sdk/Auth/AuthExtensions.cs
@@ -490,6 +490,37 @@ public static class AuthExtensions
             cancellationToken);
     }
 
+    /// <summary>
+    /// Logs out from all sessions of the user with mandatory JWT authentication.
+    /// </summary>
+    /// <param name="requestBuilder">The Logoutall request builder.</param>
+    /// <param name="request">The logout request.</param>
+    /// <param name="refreshJwt">The refresh JWT token (required for this operation).</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>The JWT response.</returns>
+    /// <exception cref="DescopeException">Thrown when refreshJwt is null or empty.</exception>
+    /// <example>
+    /// <code>
+    /// await client.Auth.V1.Logoutall.PostWithJwtAsync(new LogoutRequest(), refreshToken);
+    /// </code>
+    /// </example>
+    public static async Task<JWTResponse?> PostWithJwtAsync(
+        this Descope.Auth.V1.Auth.Logoutall.LogoutallRequestBuilder requestBuilder,
+        LogoutRequest request,
+        string refreshJwt,
+        CancellationToken cancellationToken = default)
+    {
+        if (string.IsNullOrEmpty(refreshJwt))
+        {
+            throw new DescopeException("Refresh JWT is required for logout");
+        }
+
+        return await requestBuilder.PostAsync(
+            request,
+            WithJwt(refreshJwt),
+            cancellationToken);
+    }
+
     #endregion
 
     #region Tenant Selection Extensions

--- a/Obsolete.csv
+++ b/Obsolete.csv
@@ -23,6 +23,7 @@ Descope/Generated/Auth/V1/Auth/Refresh/RefreshRequestBuilder.cs,PostAsync,PostWi
 Descope/Generated/Auth/V1/Auth/Accesskey/Exchange/ExchangeRequestBuilder.cs,PostAsync,PostWithKeyAsync
 Descope/Generated/Auth/V1/Auth/Me/MeRequestBuilder.cs,GetAsync,GetWithJwtAsync
 Descope/Generated/Auth/V1/Auth/Logout/LogoutRequestBuilder.cs,PostAsync,PostWithJwtAsync
+Descope/Generated/Auth/V1/Auth/Logoutall/LogoutallRequestBuilder.cs,PostAsync,PostWithJwtAsync
 Descope/Generated/Auth/V1/Auth/Tenant/Select/SelectRequestBuilder.cs,PostAsync,PostWithJwtAsync
 Descope/Generated/Auth/V1/Auth/Me/History/HistoryRequestBuilder.cs,GetAsync,GetWithJwtAsync
 Descope/Generated/Auth/V1/Auth/Sso/Authorize/AuthorizeRequestBuilder.cs,PostAsync,PostWithQueryParamsAsync


### PR DESCRIPTION
Fixes: https://github.com/descope/etc/issues/17919

## Summary

`LogoutAll` had no way to pass a refresh JWT explicitly, unlike [`Logout`](https://github.com/descope/descope-dotnet/blob/4ab74361379707ef9a28a563af12d16802695557/Descope/Sdk/Auth/AuthExtensions.cs#L476) and the other refresh-JWT operations in `AuthExtensions`. This adds the matching extension method.

```csharp
await client.Auth.V1.Logoutall.PostWithJwtAsync(new LogoutRequest(), refreshToken);
```

## Changes

- **`Descope/Sdk/Auth/AuthExtensions.cs`** — new `PostWithJwtAsync` overload on `LogoutallRequestBuilder`, mirroring the `Logout` one: validates `refreshJwt` (throws `DescopeException` if null/empty) and passes it through `WithJwt(...)`.
- **`Obsolete.csv`** — marks the generated `Logoutall.PostAsync` obsolete in favor of `PostWithJwtAsync`, per the repo convention for wrapped generated methods.
- **`Descope/Generated/.../LogoutallRequestBuilder.cs`** — applied the two `[Obsolete]` attributes that the `post-process-obsolete` make target generates, so the committed generated file matches what `make generate` produces.
- **`Descope.Test/UnitTests/Authentication/LogoutTests.cs`** (new) — 4 tests: `Logout` and `LogoutAll` each hit the expected endpoint with the JWT attached as a `DescopeJwtOption`, plus `LogoutAll` rejecting empty/null JWT.

## Test plan

- `make dotnet-build` succeeds across all five target frameworks (netstandard2.0, net6.0, net8.0, net9.0, net10.0).
- 253 unit tests pass. Note: run on **net10.0** rather than the `make test-quick` default of net8.0, since the net8.0 runtime wasn't installed on the dev machine. The test project does compile for net8.0; CI covers the full matrix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)