### PR TITLE
fix(ci): run target frameworks one at a time

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -35,11 +35,15 @@ jobs:
       - name: Build with dotnet
         run: dotnet build --no-restore --configuration Release
       - name: Test with dotnet
-        timeout-minutes: 10
+        timeout-minutes: 30
         env:
           AppSettings__ProjectId: ${{ secrets.DOT_NET_PROJECT_ID }}
           AppSettings__ManagementKey: ${{ secrets.DOT_NET_MANAGEMENT_KEY_ID }}
-        run: dotnet test --no-build --configuration Release --logger trx --results-directory "TestResults" --blame --blame-hang --blame-hang-timeout 1min --diag "TestResults/vstest_diagnostics.log"
+        # serialized: the integration test throttle is per-process, so parallel frameworks 4x the live API rate
+        run: |
+          for tfm in net6.0 net8.0 net9.0 net10.0; do
+            dotnet test --no-build --configuration Release --framework "$tfm" --logger trx --results-directory "TestResults" --blame --blame-hang --blame-hang-timeout 1min --diag "TestResults/vstest_$tfm.log"
+          done
 
       - name: Upload dotnet test results
         if: always()

--- a/Descope.Test/IntegrationTests/RateLimitTestFixture.cs
+++ b/Descope.Test/IntegrationTests/RateLimitTestFixture.cs
@@ -8,7 +8,6 @@ namespace Descope.Test.Integration
     /// </summary>
     public abstract class RateLimitedIntegrationTest : IDisposable
     {
-        // Process-local, so CI must run one target framework at a time (see ci.yaml)
         private static readonly SemaphoreSlim _semaphore = new SemaphoreSlim(1, 1);
         private static DateTime _lastTestEndTime = DateTime.MinValue;
 

--- a/Descope.Test/IntegrationTests/RateLimitTestFixture.cs
+++ b/Descope.Test/IntegrationTests/RateLimitTestFixture.cs
@@ -8,6 +8,7 @@ namespace Descope.Test.Integration
     /// </summary>
     public abstract class RateLimitedIntegrationTest : IDisposable
     {
+        // Process-local, so CI must run one target framework at a time (see ci.yaml)
         private static readonly SemaphoreSlim _semaphore = new SemaphoreSlim(1, 1);
         private static DateTime _lastTestEndTime = DateTime.MinValue;
 


### PR DESCRIPTION
## Related Issues
Fixes: https://github.com/descope/etc/issues/18088

## Description
CI ran all four target frameworks at once, so the integration tests hit the live Descope API roughly four times faster than the throttle in `RateLimitTestFixture` allows and failed with `[E130429]` rate limit errors, always in `SsoApplicationTests`. This runs the frameworks one at a time the way the Makefile already does, and raises the step timeout from 10 to 30 minutes to fit the serial run. 

> [!IMPORTANT]
>  CI test time goes from about 6 minutes to about 24, but this must be done since any new test added was causing a rate limit failure.
> Change affects CI runs only, not local runs.

## Must
- [x] Tests
- [ ] Documentation (if applicable)
